### PR TITLE
fix: move to Blocked state when HugePages are not available

### DIFF
--- a/lib/charms/kubernetes_charm_libraries/v0/hugepages_volumes_patch.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/hugepages_volumes_patch.py
@@ -75,7 +75,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 2
+LIBPATCH = 3
 
 logger = logging.getLogger(__name__)
 
@@ -215,11 +215,11 @@ class KubernetesClient:
         Returns:
             bool: Whether the StatefulSet contains the given volumes.
         """
-        if not statefulset_spec.template.spec.volumes:
+        if not statefulset_spec.template.spec.volumes:  # type: ignore[union-attr]
             return False
         return all(
             [
-                requested_volume in statefulset_spec.template.spec.volumes
+                requested_volume in statefulset_spec.template.spec.volumes  # type: ignore[union-attr]  # noqa E501
                 for requested_volume in requested_volumes
             ]
         )
@@ -243,7 +243,7 @@ class KubernetesClient:
         container = self._get_container(container_name=container_name, containers=containers)
         return all(
             [
-                requested_volumemount in container.volumeMounts
+                requested_volumemount in container.volumeMounts  # type: ignore[operator]
                 for requested_volumemount in requested_volumemounts
             ]
         )
@@ -267,15 +267,15 @@ class KubernetesClient:
         container = self._get_container(container_name=container_name, containers=containers)
         if requested_resources.limits:
             for limit, value in requested_resources.limits.items():
-                if not container.resources.limits:
+                if not container.resources.limits:  # type: ignore[union-attr]
                     return False
-                if container.resources.limits.get(limit) != value:
+                if container.resources.limits.get(limit) != value:  # type: ignore[union-attr]
                     return False
         if requested_resources.requests:
             for request, value in requested_resources.requests.items():
-                if not container.resources.requests:
+                if not container.resources.requests:  # type: ignore[union-attr]
                     return False
-                if container.resources.requests.get(request) != value:
+                if container.resources.requests.get(request) != value:  # type: ignore[union-attr]
                     return False
         return True
 
@@ -368,7 +368,7 @@ class KubernetesClient:
             )
         containers: Iterable[Container] = statefulset.spec.template.spec.containers  # type: ignore[attr-defined]  # noqa: E501
         container = self._get_container(container_name=container_name, containers=containers)
-        return container.volumeMounts
+        return container.volumeMounts  # type: ignore[return-value]
 
     def list_container_resources(
         self, statefulset_name: str, container_name: str
@@ -398,7 +398,7 @@ class KubernetesClient:
             Container
         ] = statefulset.spec.template.spec.containers  # type: ignore[attr-defined]  # noqa: E501
         container = self._get_container(container_name=container_name, containers=containers)
-        return container.resources
+        return container.resources  # type: ignore[return-value]
 
 
 class KubernetesHugePagesPatchCharmLib(Object):
@@ -672,8 +672,8 @@ class KubernetesHugePagesPatchCharmLib(Object):
             if current_resources.requests
             else {}
         )
-        new_limits = dict(new_limits.items() | additional_resources.limits.items())
-        new_requests = dict(new_requests.items() | additional_resources.requests.items())
+        new_limits = dict(new_limits.items() | additional_resources.limits.items())  # type: ignore[union-attr]  # noqa E501
+        new_requests = dict(new_requests.items() | additional_resources.requests.items())  # type: ignore[union-attr]  # noqa E501
         new_resources = ResourceRequirements(
             limits=new_limits, requests=new_requests, claims=current_resources.claims
         )

--- a/lib/charms/kubernetes_charm_libraries/v0/multus.py
+++ b/lib/charms/kubernetes_charm_libraries/v0/multus.py
@@ -123,7 +123,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 10
+LIBPATCH = 12
 
 
 logger = logging.getLogger(__name__)
@@ -351,7 +351,7 @@ class KubernetesClient:
                 )
             )
         if privileged:
-            container.securityContext.privileged = True
+            container.securityContext.privileged = True  # type: ignore[union-attr]
         statefulset_delta = StatefulSet(
             spec=StatefulSetSpec(
                 selector=statefulset.spec.selector,  # type: ignore[attr-defined]
@@ -489,12 +489,12 @@ class KubernetesClient:
             bool
         """
         if not self._annotations_contains_multus_networks(
-            annotations=pod.metadata.annotations,
+            annotations=pod.metadata.annotations,  # type: ignore[arg-type,union-attr]
             network_annotations=network_annotations,
         ):
             return False
         if not self._container_security_context_is_set(
-            containers=pod.spec.containers,
+            containers=pod.spec.containers,  # type: ignore[union-attr]
             container_name=container_name,
             cap_net_admin=cap_net_admin,
             privileged=privileged,
@@ -537,10 +537,27 @@ class KubernetesClient:
         """
         for container in containers:
             if container.name == container_name:
-                if cap_net_admin and "NET_ADMIN" not in container.securityContext.capabilities.add:
+                if cap_net_admin and "NET_ADMIN" not in container.securityContext.capabilities.add:  # type: ignore[operator,union-attr]  # noqa E501
                     return False
-                if privileged and not container.securityContext.privileged:
+                if privileged and not container.securityContext.privileged:  # type: ignore[union-attr]  # noqa E501
                     return False
+        return True
+
+    def multus_is_available(self) -> bool:
+        """Check whether Multus is enabled leveraging existence of NAD custom resource.
+
+        Returns:
+            bool: Whether Multus is enabled
+        """
+        try:
+            list(self.client.list(res=NetworkAttachmentDefinition, namespace=self.namespace))
+        except httpx.HTTPStatusError as e:
+            if e.response.status_code == 404:
+                return False
+            else:
+                raise KubernetesMultusError(
+                    "Unexpected outcome when checking for Multus availability"
+                )
         return True
 
 
@@ -726,3 +743,11 @@ class KubernetesMultusCharmLib(Object):
     def delete_pod(self) -> None:
         """Delete the pod."""
         self.kubernetes.delete_pod(self._pod)
+
+    def multus_is_available(self) -> bool:
+        """Check whether Multus is enabled leveraging existence of NAD custom resource.
+
+        Returns:
+            bool: Whether Multus is enabled
+        """
+        return self.kubernetes.multus_is_available()

--- a/src/charm.py
+++ b/src/charm.py
@@ -807,11 +807,16 @@ class UPFOperatorCharm(CharmBase):
 
     @staticmethod
     def _hugepages_are_available() -> bool:
+        """Checks whether HugePages are available in the K8S nodes.
+
+        Returns:
+            bool: Whether HugePages are available in the K8S nodes
+        """
         client = Client()
         nodes = client.list(Node)
         if not nodes:
             return False
-        return all([node.status.capacity.get("hugepages-1Gi", "0") >= "2Gi" for node in nodes])
+        return all([node.status.allocatable.get("hugepages-1Gi", "0") >= "2Gi" for node in nodes])
 
     def _get_access_nad_config(self) -> Dict[Any, Any]:
         """Get access interface NAD config.

--- a/src/charm.py
+++ b/src/charm.py
@@ -817,7 +817,7 @@ class UPFOperatorCharm(CharmBase):
         nodes = client.list(Node)
         if not nodes:
             return False
-        return all([node.status.allocatable.get("hugepages-1Gi", "0") >= "2Gi" for node in nodes])
+        return all([node.status.allocatable.get("hugepages-1Gi", "0") >= "2Gi" for node in nodes])  # type: ignore[union-attr]  # noqa E501
 
     def _get_access_nad_config(self) -> Dict[Any, Any]:
         """Get access interface NAD config.

--- a/src/charm.py
+++ b/src/charm.py
@@ -377,7 +377,7 @@ class UPFOperatorCharm(CharmBase):
                 )
             if not self._hugepages_are_available():
                 self.unit.status = BlockedStatus("Not enough HugePages available")
-            return
+                return
         if invalid_configs := self._get_invalid_configs():
             self.unit.status = BlockedStatus(
                 f"The following configurations are not valid: {invalid_configs}"

--- a/src/charm.py
+++ b/src/charm.py
@@ -136,6 +136,7 @@ class UPFOperatorCharm(CharmBase):
             hugepages_volumes_func=self._volumes_request_func_from_config,
             refresh_event=self.on.hugepages_volumes_config_changed,
         )
+        self.framework.observe(self.on.update_status, self._on_config_changed)
         self.framework.observe(self.on.config_changed, self._on_config_changed)
         self.framework.observe(self.on.bessd_pebble_ready, self._on_bessd_pebble_ready)
         self.framework.observe(self.on.config_storage_attached, self._on_bessd_pebble_ready)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -786,16 +786,16 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.list")
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    def test_given_cpu_supporting_required_hugepages_instructions_when_hugepages_enabled_then_charm_goes_to_maintenance_status(  # noqa: E501
+    def test_given_cpu_supporting_required_hugepages_instructions_when_hugepages_enabled_then_charm_goes_to_waiting_status(  # noqa: E501
         self, patch_hugepages_is_patched, patch_list, patched_check_output
     ):
-        patch_hugepages_is_patched.return_value = False
+        patch_hugepages_is_patched.return_value = True
         patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        patch_list.return_value = [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))]
+        patch_list.side_effect = [[Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))], []]
 
         self.harness.update_config(key_values={"enable-hugepages": True})
 
-        self.assertEqual(self.harness.model.unit.status, MaintenanceStatus())
+        self.assertEqual(self.harness.model.unit.status, WaitingStatus("Waiting for bessd container to be ready"))
 
     @patch("charm.check_output")
     @patch("lightkube.core.client.GenericSyncClient", new=Mock)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -770,6 +770,18 @@ class TestCharm(unittest.TestCase):
             namespace=self.namespace,
         )
 
+    @patch("charm.check_output")
+    @patch("charm.Client", new=Mock)
+    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
+    def test_given_cpu_not_supporting_required_hugepages_instructions_when_hugepages_enabled_then_incompatiblecpuerror_is_raised(  # noqa: E501
+        self, patch_hugepages_is_patched, patched_check_output
+    ):
+        patch_hugepages_is_patched.return_value = False
+        patched_check_output.return_value = b"Flags: ssse3 fma cx16 rdrand"
+
+        with self.assertRaises(IncompatibleCPUError):
+            self.harness.update_config(key_values={"enable-hugepages": True})
+
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_no_interface_mtu_specified_in_nad(  # noqa: E501
         self,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -791,7 +791,7 @@ class TestCharm(unittest.TestCase):
     ):
         patch_hugepages_is_patched.return_value = False
         patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        patch_list.return_value = [Node(status=NodeStatus(capacity={"hugepages-1Gi": "3Gi"}))]
+        patch_list.return_value = [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))]
 
         self.harness.update_config(key_values={"enable-hugepages": True})
 
@@ -806,7 +806,7 @@ class TestCharm(unittest.TestCase):
     ):
         patch_hugepages_is_patched.return_value = False
         patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        patch_list.return_value = [Node(status=NodeStatus(capacity={"hugepages-1Gi": "1Gi"}))]
+        patch_list.return_value = [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "1Gi"}))]
 
         self.harness.update_config(key_values={"enable-hugepages": True})
 


### PR DESCRIPTION
# Description

This PR adds two validations to the UPF charm when enabling HugePages: the first is the support of the required CPU flags (`pdpe1gb`); the second is the capacity of enough HugePages (2Gi) on the K8S nodes. If the free HugePages (allocatable minus allocated) are not enough, the charm will remain in Waiting status.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
