### PR TITLE
fix: move to Blocked state when Multus is disabled

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -379,6 +379,9 @@ class UPFOperatorCharm(CharmBase):
             if not self._hugepages_are_available():
                 self.unit.status = BlockedStatus("Not enough HugePages available")
                 return
+        if not self._kubernetes_multus.multus_is_available():
+            self.unit.status = BlockedStatus("Multus is not installed or enabled")
+            return
         if invalid_configs := self._get_invalid_configs():
             self.unit.status = BlockedStatus(
                 f"The following configurations are not valid: {invalid_configs}"


### PR DESCRIPTION
# Description

This PR aims to fix #74 . If Multus is not installed or enabled, move to Blocked state.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library