### PR TITLE
fix: Add 'enable-hw-checksum' configuration, disabled by default

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -67,3 +67,10 @@ options:
     description: |
       When enabled, HugePages of 1Gi will be used for a total of 2Gi HugePages.
       HugePages must be enabled if `upf-mode` is `dpdk`.
+  enable-hw-checksum:
+    type: boolean
+    default: false
+    description: |
+      When enabled, hardware checksum will be used on the network interfaces.
+      Only has an effect when `upf-mode` is `dpdk` and must be supported by
+      the hardware.

--- a/src/charm.py
+++ b/src/charm.py
@@ -553,6 +553,7 @@ class UPFOperatorCharm(CharmBase):
             core_ip_address=core_ip_address.split("/")[0] if core_ip_address else "",
             dnn=self._get_dnn_config(),  # type: ignore[arg-type]
             pod_share_path=POD_SHARE_PATH,
+            enable_hw_checksum=self._get_enable_hw_checksum(),
         )
         if not self._bessd_config_file_is_written() or not self._bessd_config_file_content_matches(
             content=content
@@ -858,6 +859,14 @@ class UPFOperatorCharm(CharmBase):
 
     def _get_dnn_config(self) -> Optional[str]:
         return self.model.config.get("dnn")
+
+    def _get_enable_hw_checksum(self) -> bool:
+        """Reads the `enable-hw-checksum` charm config.
+
+        Returns:
+            bool: Whether hardware checksum should be enabled
+        """
+        return bool(self.model.config.get("enable-hw-checksum", False))
 
     def _core_ip_config_is_valid(self) -> bool:
         """Checks whether the core-ip config is valid.
@@ -1176,6 +1185,7 @@ def render_bessd_config_file(
     core_ip_address: Optional[str],
     dnn: str,
     pod_share_path: str,
+    enable_hw_checksum: bool,
 ) -> str:
     """Renders the configuration file for the 5G UPF service.
 
@@ -1187,6 +1197,7 @@ def render_bessd_config_file(
         core_ip_address: Core network IP address
         dnn: Data Network Name (DNN)
         pod_share_path: pod_share path
+        enable_hw_checksum: Whether to enable hardware checksum or not
     """
     jinja2_environment = Environment(loader=FileSystemLoader("src/templates/"))
     template = jinja2_environment.get_template(f"{CONFIG_FILE_NAME}.j2")
@@ -1198,6 +1209,7 @@ def render_bessd_config_file(
         core_ip_address=core_ip_address,
         dnn=dnn,
         pod_share_path=pod_share_path,
+        hwcksum=str(enable_hw_checksum).lower(),
     )
     return content
 

--- a/src/templates/upf.json.j2
+++ b/src/templates/upf.json.j2
@@ -14,7 +14,7 @@
   },
   "enable_notify_bess": true,
   "gtppsc": true,
-  "hwcksum": true,
+  "hwcksum": {{ hwcksum }},
   "log_level": "trace",
   "max_sessions": 50000,
   "measure_flow": false,

--- a/tests/unit/expected_upf.json
+++ b/tests/unit/expected_upf.json
@@ -14,7 +14,7 @@
   },
   "enable_notify_bess": true,
   "gtppsc": true,
-  "hwcksum": true,
+  "hwcksum": false,
   "log_level": "trace",
   "max_sessions": 50000,
   "measure_flow": false,


### PR DESCRIPTION
# Description

This adds `enable-hw-checksum` boolean configuration, set to `False` by default. This fixes an issue when using DPDK on interfaces that do not support hardware checksum offloading.

The current behavior is for BESS to crash with a cryptic error (`Error: rte_eth_dev_configure() failed`) when trying to setup the interfaces. This can happen when testing DPDK on virtual interfaces, but could also happen on any hardware NIC that does not support hardware checksums.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
