### PR TITLE
fix: Changing default value of hwcksum to true

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -69,7 +69,7 @@ options:
       HugePages must be enabled if `upf-mode` is `dpdk`.
   enable-hw-checksum:
     type: boolean
-    default: false
+    default: true
     description: |
       When enabled, hardware checksum will be used on the network interfaces.
       Only has an effect when `upf-mode` is `dpdk` and must be supported by

--- a/config.yaml
+++ b/config.yaml
@@ -72,5 +72,3 @@ options:
     default: true
     description: |
       When enabled, hardware checksum will be used on the network interfaces.
-      Only has an effect when `upf-mode` is `dpdk` and must be supported by
-      the hardware.

--- a/tests/unit/expected_upf.json
+++ b/tests/unit/expected_upf.json
@@ -14,7 +14,7 @@
   },
   "enable_notify_bess": true,
   "gtppsc": true,
-  "hwcksum": false,
+  "hwcksum": true,
   "log_level": "trace",
   "max_sessions": 50000,
   "measure_flow": false,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1838,9 +1838,9 @@ class TestCharm(unittest.TestCase):
         self, _
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        self.harness.update_config(key_values={"enable-hw-checksum": True})
+        self.harness.update_config(key_values={"enable-hw-checksum": False})
         self.harness.container_pebble_ready(container_name="bessd")
 
         config = json.loads((self.root / "etc/bess/conf/upf.json").read_text())
         self.assertIn("hwcksum", config)
-        self.assertTrue(config["hwcksum"])
+        self.assertFalse(config["hwcksum"])


### PR DESCRIPTION
# Description

Changes the default value of `enable-hw-checksum` to True. Setting it to False breaks the simulation.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
