### PR TITLE
feat: use Pydantic validator and support for new CNIs

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -2,6 +2,9 @@ options:
   cni-type:
     type: string
     default: bridge
+    description: |
+      Multus CNI plugin to use for the interfaces.
+      Allowed values are `bridge`, `host-device`, `macvlan`, `vfioveth`.
   upf-mode:
     type: string
     default: af_packet

--- a/config.yaml
+++ b/config.yaml
@@ -1,4 +1,7 @@
 options:
+  cni-type:
+    type: string
+    default: bridge
   upf-mode:
     type: string
     default: af_packet
@@ -61,12 +64,6 @@ options:
       If not provided, it will default to the LoadBalancer Service hostname. 
       If that is not available, it will default to the internal
       Kubernetes FQDN of the service.
-  enable-hugepages:
-    type: boolean
-    default: false
-    description: |
-      When enabled, HugePages of 1Gi will be used for a total of 2Gi HugePages.
-      HugePages must be enabled if `upf-mode` is `dpdk`.
   enable-hw-checksum:
     type: boolean
     default: true

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ jinja2
 lightkube
 lightkube-models
 macaddress
-pydantic
+pydantic>=2
+pydantic_extra_types
 pytest-interface-tester
 PyYAML>=6.0.1
 cosl # required by prometheus_k8s.v0.prometheus_scrape

--- a/src/charm.py
+++ b/src/charm.py
@@ -237,7 +237,7 @@ class UPFOperatorCharm(CharmBase):
 
     def _update_fiveg_n3_relation_data(self) -> None:
         """Publishes UPF IP address in the `fiveg_n3` relation data bag."""
-        upf_access_ip_address = self._get_network_ip_config("access").split("/")[0]  # type: ignore[union-attr]  # noqa: E501
+        upf_access_ip_address = self._get_network_ip_config(ACCESS_INTERFACE_NAME).split("/")[0]  # type: ignore[union-attr]  # noqa: E501
         fiveg_n3_relations = self.model.relations.get("fiveg_n3")
         if not fiveg_n3_relations:
             logger.info("No `fiveg_n3` relations found.")
@@ -303,10 +303,10 @@ class UPFOperatorCharm(CharmBase):
             interface=CORE_INTERFACE_NAME,
         )
         if self._get_upf_mode() == "dpdk":
-            access_network_annotation.mac = self._get_interface_mac_address("access")
-            access_network_annotation.ips = [self._get_network_ip_config("access")]
-            core_network_annotation.mac = self._get_interface_mac_address("core")
-            core_network_annotation.ips = [self._get_network_ip_config("core")]
+            access_network_annotation.mac = self._get_interface_mac_address(ACCESS_INTERFACE_NAME)
+            access_network_annotation.ips = [self._get_network_ip_config(ACCESS_INTERFACE_NAME)]
+            core_network_annotation.mac = self._get_interface_mac_address(CORE_INTERFACE_NAME)
+            core_network_annotation.ips = [self._get_network_ip_config(CORE_INTERFACE_NAME)]
         return [access_network_annotation, core_network_annotation]
 
     def _network_attachment_definitions_from_config(self) -> list[NetworkAttachmentDefinition]:
@@ -319,8 +319,8 @@ class UPFOperatorCharm(CharmBase):
             access_nad = self._create_dpdk_access_nad_from_config()
             core_nad = self._create_dpdk_core_nad_from_config()
         else:
-            access_nad = self._create_nad_from_config("access")
-            core_nad = self._create_nad_from_config("core")
+            access_nad = self._create_nad_from_config(ACCESS_INTERFACE_NAME)
+            core_nad = self._create_nad_from_config(CORE_INTERFACE_NAME)
 
         return [access_nad, core_nad]
 
@@ -356,7 +356,7 @@ class UPFOperatorCharm(CharmBase):
                 {
                     "bridge": (
                         ACCESS_INTERFACE_BRIDGE_NAME
-                        if interface_name == "access"
+                        if interface_name == ACCESS_INTERFACE_NAME
                         else CORE_INTERFACE_BRIDGE_NAME
                     )
                 }
@@ -367,7 +367,7 @@ class UPFOperatorCharm(CharmBase):
             metadata=ObjectMeta(
                 name=(
                     CORE_NETWORK_ATTACHMENT_DEFINITION_NAME
-                    if interface_name == "core"
+                    if interface_name == CORE_INTERFACE_NAME
                     else ACCESS_NETWORK_ATTACHMENT_DEFINITION_NAME
                 )
             ),
@@ -516,7 +516,7 @@ class UPFOperatorCharm(CharmBase):
         Writes configuration file, creates routes, creates iptable rule and pebble layer.
         """
         restart = False
-        core_ip_address = self._get_network_ip_config("core")
+        core_ip_address = self._get_network_ip_config(CORE_INTERFACE_NAME)
         content = render_bessd_config_file(
             upf_hostname=self._upf_hostname,
             upf_mode=self._get_upf_mode(),  # type: ignore[arg-type]
@@ -769,9 +769,9 @@ class UPFOperatorCharm(CharmBase):
         Returns:
             Optional[str]: The network IP address to use
         """
-        if interface_name == "access":
+        if interface_name == ACCESS_INTERFACE_NAME:
             return str(self._charm_config.upf_config.access_ip)
-        elif interface_name == "core":
+        elif interface_name == CORE_INTERFACE_NAME:
             return str(self._charm_config.upf_config.core_ip)
         else:
             return None
@@ -785,9 +785,9 @@ class UPFOperatorCharm(CharmBase):
         Returns:
             Optional[str]: The interface on the host to use
         """
-        if interface_name == "access":
+        if interface_name == ACCESS_INTERFACE_NAME:
             return self._charm_config.upf_config.access_interface
-        elif interface_name == "core":
+        elif interface_name == CORE_INTERFACE_NAME:
             return self._charm_config.upf_config.core_interface
         else:
             return None
@@ -801,9 +801,9 @@ class UPFOperatorCharm(CharmBase):
         Returns:
             Optional[str]: The MAC address to use
         """
-        if interface_name == "access":
+        if interface_name == ACCESS_INTERFACE_NAME:
             return self._charm_config.upf_config.access_interface_mac_address
-        elif interface_name == "core":
+        elif interface_name == CORE_INTERFACE_NAME:
             return self._charm_config.upf_config.core_interface_mac_address
         else:
             return None
@@ -817,9 +817,9 @@ class UPFOperatorCharm(CharmBase):
         Returns:
             Optional[str]: The gateway IP address to use
         """
-        if interface_name == "access":
+        if interface_name == ACCESS_INTERFACE_NAME:
             return str(self._charm_config.upf_config.access_gateway_ip)
-        elif interface_name == "core":
+        elif interface_name == CORE_INTERFACE_NAME:
             return str(self._charm_config.upf_config.core_gateway_ip)
         else:
             return None
@@ -929,9 +929,9 @@ class UPFOperatorCharm(CharmBase):
         Returns:
             Optional[int]: The MTU to use for the specified interface
         """
-        if interface_name == "access":
+        if interface_name == ACCESS_INTERFACE_NAME:
             return self._charm_config.upf_config.access_interface_mtu_size
-        elif interface_name == "core":
+        elif interface_name == CORE_INTERFACE_NAME:
             return self._charm_config.upf_config.core_interface_mtu_size
         else:
             return None

--- a/src/charm.py
+++ b/src/charm.py
@@ -36,7 +36,7 @@ from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, Container, ModelError, WaitingStatus
 from ops.pebble import ExecError, Layer
 
-from charm_state import CharmConfigInvalidError, CharmState
+from charm_config import CharmConfig, CharmConfigInvalidError
 from dpdk import DPDK
 
 logger = logging.getLogger(__name__)
@@ -325,7 +325,7 @@ class UPFOperatorCharm(CharmBase):
         Returns:
             NetworkAttachmentDefinition: NetworkAttachmentDefinition object
         """
-        nad_config = self._get_nad_base_config(interface_name)
+        nad_config = self._get_nad_base_config()
         cni_type = self._get_cni_type_config()
         # MTU is optional for bridge, macvlan, dpdk
         # MTU is ignored by host-device
@@ -364,7 +364,7 @@ class UPFOperatorCharm(CharmBase):
         Returns:
             NetworkAttachmentDefinition: NetworkAttachmentDefinition object
         """
-        access_nad_config = self._get_nad_base_config("access")
+        access_nad_config = self._get_nad_base_config()
         access_nad_config.update({"type": "vfioveth"})
 
         return NetworkAttachmentDefinition(
@@ -383,7 +383,7 @@ class UPFOperatorCharm(CharmBase):
         Returns:
             NetworkAttachmentDefinition: NetworkAttachmentDefinition object
         """
-        core_nad_config = self._get_nad_base_config("core")
+        core_nad_config = self._get_nad_base_config()
         core_nad_config.update({"type": "vfioveth"})
 
         return NetworkAttachmentDefinition(
@@ -397,7 +397,7 @@ class UPFOperatorCharm(CharmBase):
         )
 
     @staticmethod
-    def _get_nad_base_config(self) -> Dict[Any, Any]:
+    def _get_nad_base_config() -> Dict[Any, Any]:
         """Base NetworkAttachmentDefinition config to be extended according to charm config.
 
         Returns:
@@ -457,7 +457,7 @@ class UPFOperatorCharm(CharmBase):
             self.unit.status = BlockedStatus("Multus is not installed or enabled")
             return
         try:
-            CharmState.from_charm(charm=self)
+            CharmConfig.from_charm(charm=self)
         except CharmConfigInvalidError as e:
             self.unit.status = BlockedStatus(e.msg)
             return
@@ -477,7 +477,7 @@ class UPFOperatorCharm(CharmBase):
         if not self.unit.is_leader():
             return
         try:
-            CharmState.from_charm(charm=self)
+            CharmConfig.from_charm(charm=self)
         except CharmConfigInvalidError as e:
             self.unit.status = BlockedStatus(e.msg)
             return
@@ -669,7 +669,7 @@ class UPFOperatorCharm(CharmBase):
     def _set_unit_status(self) -> None:
         """Set the unit status based on config and container services running."""
         try:
-            CharmState.from_charm(charm=self)
+            CharmConfig.from_charm(charm=self)
         except CharmConfigInvalidError as e:
             self.unit.status = BlockedStatus(e.msg)
             return

--- a/src/charm.py
+++ b/src/charm.py
@@ -349,7 +349,15 @@ class UPFOperatorCharm(CharmBase):
             elif cni_type == "host-device":
                 nad_config.update({"device": host_interface})
         else:
-            nad_config.update({"bridge": ACCESS_INTERFACE_BRIDGE_NAME})
+            nad_config.update(
+                {
+                    "bridge": (
+                        ACCESS_INTERFACE_BRIDGE_NAME
+                        if interface_name == "access"
+                        else CORE_INTERFACE_BRIDGE_NAME
+                    )
+                }
+            )
         nad_config.update({"type": cni_type})
 
         return NetworkAttachmentDefinition(

--- a/src/charm.py
+++ b/src/charm.py
@@ -59,7 +59,6 @@ PROMETHEUS_PORT = 8080
 PFCP_PORT = 8805
 REQUIRED_CPU_EXTENSIONS = ["avx2", "rdrand"]
 REQUIRED_CPU_EXTENSIONS_HUGEPAGES = ["pdpe1gb"]
-SUPPORTED_UPF_MODES = ["af_packet", "dpdk"]
 
 # The default field manager set when using kubectl to create resources
 DEFAULT_FIELD_MANAGER = "controller"
@@ -617,14 +616,14 @@ class UPFOperatorCharm(CharmBase):
     def _create_default_route(self) -> None:
         """Creates ip route towards core network."""
         self._exec_command_in_bessd_workload(
-            command=f"ip route replace default via {self._get_network_gateway_ip_config('core')} metric 110"  # noqa: E501
+            command=f"ip route replace default via {self._get_network_gateway_ip_config(CORE_INTERFACE_NAME)} metric 110"  # noqa: E501
         )
         logger.info("Default core network route created")
 
     def _create_ran_route(self) -> None:
         """Creates ip route towards gnb-subnet."""
         self._exec_command_in_bessd_workload(
-            command=f"ip route replace {self._get_gnb_subnet_config()} via {self._get_network_gateway_ip_config('access')}"  # noqa: E501
+            command=f"ip route replace {self._get_gnb_subnet_config()} via {self._get_network_gateway_ip_config(ACCESS_INTERFACE_NAME)}"  # noqa: E501
         )
         logger.info("Route to gnb-subnet created")
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -463,6 +463,12 @@ class UPFOperatorCharm(CharmBase):
 
     def _on_config_changed(self, event: EventBase):
         """Handler for config changed events."""
+        # workaround for https://github.com/canonical/operator/issues/736
+        try:
+            self._charm_config: CharmConfig = CharmConfig.from_charm(charm=self)  # type: ignore[no-redef]  # noqa: E501
+        except CharmConfigInvalidError as exc:
+            self.model.unit.status = BlockedStatus(exc.msg)
+            return
         if not self.unit.is_leader():
             return
 
@@ -484,6 +490,12 @@ class UPFOperatorCharm(CharmBase):
 
     def _on_bessd_pebble_ready(self, event: EventBase) -> None:
         """Handle Pebble ready event."""
+        # workaround for https://github.com/canonical/operator/issues/736
+        try:
+            self._charm_config: CharmConfig = CharmConfig.from_charm(charm=self)  # type: ignore[no-redef]  # noqa: E501
+        except CharmConfigInvalidError as exc:
+            self.model.unit.status = BlockedStatus(exc.msg)
+            return
         if not self.unit.is_leader():
             return
         if not self._is_cpu_compatible():

--- a/src/charm.py
+++ b/src/charm.py
@@ -756,10 +756,10 @@ class UPFOperatorCharm(CharmBase):
         }
 
     def _get_upf_mode(self) -> Optional[str]:
-        return self._charm_config.upf_config.upf_mode
+        return self._charm_config.upf_mode
 
     def _get_dnn_config(self) -> Optional[str]:
-        return self._charm_config.upf_config.dnn
+        return self._charm_config.dnn
 
     def _get_enable_hw_checksum(self) -> bool:
         """Reads the `enable-hw-checksum` charm config.
@@ -767,7 +767,7 @@ class UPFOperatorCharm(CharmBase):
         Returns:
             bool: Whether hardware checksum should be enabled
         """
-        return bool(self._charm_config.upf_config.enable_hw_checksum)
+        return bool(self._charm_config.enable_hw_checksum)
 
     def _get_network_ip_config(self, interface_name: str) -> Optional[str]:
         """Retrieves the network IP address to use for the specified interface.
@@ -779,9 +779,9 @@ class UPFOperatorCharm(CharmBase):
             Optional[str]: The network IP address to use
         """
         if interface_name == ACCESS_INTERFACE_NAME:
-            return str(self._charm_config.upf_config.access_ip)
+            return str(self._charm_config.access_ip)
         elif interface_name == CORE_INTERFACE_NAME:
-            return str(self._charm_config.upf_config.core_ip)
+            return str(self._charm_config.core_ip)
         else:
             return None
 
@@ -795,9 +795,9 @@ class UPFOperatorCharm(CharmBase):
             Optional[str]: The interface on the host to use
         """
         if interface_name == ACCESS_INTERFACE_NAME:
-            return self._charm_config.upf_config.access_interface
+            return self._charm_config.access_interface
         elif interface_name == CORE_INTERFACE_NAME:
-            return self._charm_config.upf_config.core_interface
+            return self._charm_config.core_interface
         else:
             return None
 
@@ -811,9 +811,9 @@ class UPFOperatorCharm(CharmBase):
             Optional[str]: The MAC address to use
         """
         if interface_name == ACCESS_INTERFACE_NAME:
-            return self._charm_config.upf_config.access_interface_mac_address
+            return self._charm_config.access_interface_mac_address
         elif interface_name == CORE_INTERFACE_NAME:
-            return self._charm_config.upf_config.core_interface_mac_address
+            return self._charm_config.core_interface_mac_address
         else:
             return None
 
@@ -827,17 +827,17 @@ class UPFOperatorCharm(CharmBase):
             Optional[str]: The gateway IP address to use
         """
         if interface_name == ACCESS_INTERFACE_NAME:
-            return str(self._charm_config.upf_config.access_gateway_ip)
+            return str(self._charm_config.access_gateway_ip)
         elif interface_name == CORE_INTERFACE_NAME:
-            return str(self._charm_config.upf_config.core_gateway_ip)
+            return str(self._charm_config.core_gateway_ip)
         else:
             return None
 
     def _get_gnb_subnet_config(self) -> Optional[str]:
-        return str(self._charm_config.upf_config.gnb_subnet)
+        return str(self._charm_config.gnb_subnet)
 
     def _get_external_upf_hostname_config(self) -> Optional[str]:
-        return self._charm_config.upf_config.external_upf_hostname
+        return self._charm_config.external_upf_hostname
 
     def _upf_load_balancer_service_hostname(self) -> Optional[str]:
         """Returns the hostname of UPF's LoadBalancer service.
@@ -939,14 +939,14 @@ class UPFOperatorCharm(CharmBase):
             Optional[int]: The MTU to use for the specified interface
         """
         if interface_name == ACCESS_INTERFACE_NAME:
-            return self._charm_config.upf_config.access_interface_mtu_size
+            return self._charm_config.access_interface_mtu_size
         elif interface_name == CORE_INTERFACE_NAME:
-            return self._charm_config.upf_config.core_interface_mtu_size
+            return self._charm_config.core_interface_mtu_size
         else:
             return None
 
     def _get_cni_type_config(self) -> Optional[str]:
-        return self._charm_config.upf_config.cni_type
+        return self._charm_config.cni_type
 
     def _hugepages_is_enabled(self) -> bool:
         """Returns whether HugePages are enabled.

--- a/src/charm.py
+++ b/src/charm.py
@@ -883,73 +883,21 @@ class UPFOperatorCharm(CharmBase):
             return False
         return all([node.status.allocatable.get("hugepages-1Gi", "0") >= "2Gi" for node in nodes])  # type: ignore[union-attr]  # noqa E501
 
-    def _get_access_nad_config(self) -> Dict[Any, Any]:
-        """Get access interface NAD config.
-
-        Returns:
-            config (dict): Access interface NAD config
-
-        """
-        config = {
-            "cniVersion": "0.3.1",
-            "ipam": {
-                "type": "static",
-                "routes": [
-                    {
-                        "dst": self._get_gnb_subnet_config(),
-                        "gw": self._get_network_gateway_ip_config("access"),
-                    },
-                ],
-                "addresses": [
-                    {
-                        "address": self._get_network_ip_config("access"),
-                    }
-                ],
-            },
-            "capabilities": {"mac": True},
-        }
-        if access_mtu := self._get_interface_mtu_config("access"):
-            config.update({"mtu": access_mtu})
-        return config
-
-    def _get_core_nad_config(self) -> Dict[Any, Any]:
-        """Get core interface NAD config.
-
-        Returns:
-            config (dict): Core interface NAD config
-
-        """
-        config = {
-            "cniVersion": "0.3.1",
-            "ipam": {
-                "type": "static",
-                "addresses": [
-                    {
-                        "address": self._get_network_ip_config("core"),
-                    }
-                ],
-            },
-            "capabilities": {"mac": True},
-        }
-        if core_mtu := self._get_interface_mtu_config("core"):
-            config.update({"mtu": core_mtu})
-        return config
-
-    def _get_interface_mtu_config(self, interface_name) -> Optional[str]:
+    def _get_interface_mtu_config(self, interface_name) -> Optional[int]:
         """Get MTU size for the specified interface.
 
         Args:
             interface_name: str
 
         Returns:
-            mtu_size (str/None): If MTU size is not configured return None
+            mtu_size (int/None): If MTU size is not configured return None
                                     If it is set, returns the configured value
 
         """
         if interface_name == "access":
-            return str(self._charm_config.upf_config.access_interface_mtu_size)
+            return self._charm_config.upf_config.access_interface_mtu_size
         elif interface_name == "core":
-            return str(self._charm_config.upf_config.core_interface_mtu_size)
+            return self._charm_config.upf_config.core_interface_mtu_size
         else:
             return None
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -325,7 +325,10 @@ class UPFOperatorCharm(CharmBase):
         return [access_nad, core_nad]
 
     def _create_nad_from_config(self, interface_name: str) -> NetworkAttachmentDefinition:
-        """Returns a NetworkAttachmentDefinition for the Core interface.
+        """Returns a NetworkAttachmentDefinition for the specified interface.
+
+        Args:
+            interface_name (str): Interface name to create the NetworkAttachmentDefinition from
 
         Returns:
             NetworkAttachmentDefinition: NetworkAttachmentDefinition object
@@ -416,14 +419,13 @@ class UPFOperatorCharm(CharmBase):
         Returns:
             config (dict): Base NAD config
         """
-        base_nad_config = {
+        return {
             "cniVersion": "0.3.1",
             "ipam": {
                 "type": "static",
             },
             "capabilities": {"mac": True},
         }
-        return base_nad_config
 
     def _write_bessd_config_file(self, content: str) -> None:
         """Write the configuration file for the 5G UPF service.
@@ -759,6 +761,14 @@ class UPFOperatorCharm(CharmBase):
         return bool(self._charm_config.upf_config.enable_hw_checksum)
 
     def _get_network_ip_config(self, interface_name: str) -> Optional[str]:
+        """Retrieves the network IP address to use for the specified interface.
+
+        Args:
+            interface_name (str): Interface name to retrieve the network IP address from
+
+        Returns:
+            Optional[str]: The network IP address to use
+        """
         if interface_name == "access":
             return str(self._charm_config.upf_config.access_ip)
         elif interface_name == "core":
@@ -767,6 +777,14 @@ class UPFOperatorCharm(CharmBase):
             return None
 
     def _get_interface_config(self, interface_name: str) -> Optional[str]:
+        """Retrieves the interface on the host to use for the specified interface.
+
+        Args:
+            interface_name (str): Interface name to retrieve the interface host from
+
+        Returns:
+            Optional[str]: The interface on the host to use
+        """
         if interface_name == "access":
             return self._charm_config.upf_config.access_interface
         elif interface_name == "core":
@@ -775,10 +793,13 @@ class UPFOperatorCharm(CharmBase):
             return None
 
     def _get_interface_mac_address(self, interface_name: str) -> Optional[str]:
-        """Reads the `access-interface-mac-address` charm config.
+        """Retrieves the MAC address to use for the specified interface.
+
+        Args:
+            interface_name (str): Interface name to retrieve the MAC address from
 
         Returns:
-            Optional[str]: The `access-interface-mac-address` charm config
+            Optional[str]: The MAC address to use
         """
         if interface_name == "access":
             return self._charm_config.upf_config.access_interface_mac_address
@@ -788,6 +809,14 @@ class UPFOperatorCharm(CharmBase):
             return None
 
     def _get_network_gateway_ip_config(self, interface_name: str) -> Optional[str]:
+        """Retrieves the gateway IP address to use for the specified interface.
+
+        Args:
+            interface_name (str): Interface name to retrieve the gateway IP address from
+
+        Returns:
+            Optional[str]: The gateway IP address to use
+        """
         if interface_name == "access":
             return str(self._charm_config.upf_config.access_gateway_ip)
         elif interface_name == "core":
@@ -892,15 +921,13 @@ class UPFOperatorCharm(CharmBase):
         return all([node.status.allocatable.get("hugepages-1Gi", "0") >= "2Gi" for node in nodes])  # type: ignore[union-attr]  # noqa E501
 
     def _get_interface_mtu_config(self, interface_name) -> Optional[int]:
-        """Get MTU size for the specified interface.
+        """Retrieves the MTU to use for the specified interface.
 
         Args:
-            interface_name: str
+            interface_name (str): Interface name to retrieve the MTU from
 
         Returns:
-            mtu_size (int/None): If MTU size is not configured return None
-                                    If it is set, returns the configured value
-
+            Optional[int]: The MTU to use for the specified interface
         """
         if interface_name == "access":
             return self._charm_config.upf_config.access_interface_mtu_size

--- a/src/charm.py
+++ b/src/charm.py
@@ -337,9 +337,7 @@ class UPFOperatorCharm(CharmBase):
         cni_type = self._get_cni_type_config()
         # MTU is optional for bridge, macvlan, dpdk
         # MTU is ignored by host-device
-        if cni_type == CNIType.host_device:
-            pass
-        else:
+        if cni_type != CNIType.host_device:
             if interface_mtu := self._get_interface_mtu_config(interface_name):
                 nad_config.update({"mtu": interface_mtu})
         nad_config["ipam"].update(

--- a/src/charm.py
+++ b/src/charm.py
@@ -755,12 +755,16 @@ class UPFOperatorCharm(CharmBase):
             return str(self._charm_config.upf_config.access_ip)
         elif interface_name == "core":
             return str(self._charm_config.upf_config.core_ip)
+        else:
+            return None
 
     def _get_interface_config(self, interface_name: str) -> Optional[str]:
         if interface_name == "access":
             return self._charm_config.upf_config.access_interface
         elif interface_name == "core":
             return self._charm_config.upf_config.core_interface
+        else:
+            return None
 
     def _get_interface_mac_address(self, interface_name: str) -> Optional[str]:
         """Reads the `access-interface-mac-address` charm config.
@@ -772,12 +776,16 @@ class UPFOperatorCharm(CharmBase):
             return self._charm_config.upf_config.access_interface_mac_address
         elif interface_name == "core":
             return self._charm_config.upf_config.core_interface_mac_address
+        else:
+            return None
 
     def _get_network_gateway_ip_config(self, interface_name: str) -> Optional[str]:
         if interface_name == "access":
             return str(self._charm_config.upf_config.access_gateway_ip)
         elif interface_name == "core":
             return str(self._charm_config.upf_config.core_gateway_ip)
+        else:
+            return None
 
     def _get_gnb_subnet_config(self) -> Optional[str]:
         return str(self._charm_config.upf_config.gnb_subnet)
@@ -939,9 +947,11 @@ class UPFOperatorCharm(CharmBase):
 
         """
         if interface_name == "access":
-            return self._charm_config.upf_config.access_interface_mtu_size
+            return str(self._charm_config.upf_config.access_interface_mtu_size)
         elif interface_name == "core":
-            return self._charm_config.upf_config.core_interface_mtu_size
+            return str(self._charm_config.upf_config.core_interface_mtu_size)
+        else:
+            return None
 
     def _get_cni_type_config(self) -> Optional[str]:
         return self._charm_config.upf_config.cni_type

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -72,14 +72,14 @@ class UpfConfig(BaseModel):  # pylint: disable=too-few-public-methods
     dnn: StrictStr = Field(default="internet", min_length=1)
     gnb_subnet: IPvAnyNetwork = IPvAnyNetwork("192.168.251.0/24")
     access_interface: Optional[StrictStr] = Field(default="")
-    access_interface_mac_address: MacAddress = Field(default=None)
+    access_interface_mac_address: Optional[StrictStr] = Field(default="")
     access_ip: str = Field(default="192.168.252.3/24")
     access_gateway_ip: IPvAnyAddress = IPvAnyAddress("192.168.252.1")
     access_interface_mtu_size: Optional[int] = Field(
         default=None, ge=1200, le=65535, validate_default=True
     )
     core_interface: Optional[StrictStr] = Field(default="")
-    core_interface_mac_address: MacAddress = Field(default=None)
+    core_interface_mac_address: Optional[StrictStr] = Field(default="")
     core_ip: str = Field(default="192.168.250.3/24")
     core_gateway_ip: IPvAnyAddress = IPvAnyAddress("192.168.250.1")
     core_interface_mtu_size: Optional[int] = Field(default=None, ge=1200, le=65535)
@@ -105,6 +105,13 @@ class UpfConfig(BaseModel):  # pylint: disable=too-few-public-methods
     def validate_ip_network_address(cls, value: str, info: ValidationInfo) -> str:
         """Validate that IP network address is valid."""
         ip_network(value, strict=False)
+        return value
+
+    @field_validator("access_interface_mac_address", "core_interface_mac_address", mode="before")
+    @classmethod
+    def validate_interface_mac_address(cls, value: str, info: ValidationInfo) -> str:
+        """Validate that IP network address is valid."""
+        MacAddress.validate_mac_address(value.encode())
         return value
 
 

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -1,7 +1,7 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-"""State of the Charm."""
+"""Config of the Charm."""
 
 import dataclasses
 import logging
@@ -31,8 +31,8 @@ class CNIType(str, Enum):
 
     bridge = "bridge"
     macvlan = "macvlan"
-    dpdk = "dpdk"
     host_device = "host-device"
+    vfioveth = "vfioveth"
 
 
 class UpfMode(str, Enum):
@@ -66,11 +66,7 @@ class LaxIPvAnyNetwork(IPvAnyNetwork):
 
 
 class CharmConfigInvalidError(Exception):
-    """Exception raised when a charm configuration is found to be invalid.
-
-    Attrs:
-        msg (str): Explanation of the error.
-    """
+    """Exception raised when a charm configuration is found to be invalid."""
 
     def __init__(self, msg: str):
         """Initialize a new instance of the CharmConfigInvalidError exception.
@@ -91,7 +87,7 @@ class UpfConfig(BaseModel):  # pylint: disable=too-few-public-methods
 
     model_config = ConfigDict(alias_generator=to_kebab, use_enum_values=True)
 
-    cni_type: CNIType
+    cni_type: CNIType = CNIType.bridge
     upf_mode: UpfMode = UpfMode.af_packet
     dnn: StrictStr = Field(default="internet", min_length=1)
     gnb_subnet: LaxIPvAnyNetwork = LaxIPvAnyNetwork("192.168.251.0/24")
@@ -127,8 +123,8 @@ class UpfConfig(BaseModel):  # pylint: disable=too-few-public-methods
 
 
 @dataclasses.dataclass(frozen=True)
-class CharmState:
-    """State of the Charm."""
+class CharmConfig:
+    """Config of the Charm."""
 
     upf_config: UpfConfig
 
@@ -136,7 +132,7 @@ class CharmState:
     def from_charm(
         cls,
         charm: ops.CharmBase,
-    ) -> "CharmState":
+    ) -> "CharmConfig":
         """Initialize a new instance of the CharmState class from the associated charm."""
         try:
             # ignoring because mypy fails with:

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -88,18 +88,17 @@ class UpfConfig(BaseModel):  # pylint: disable=too-few-public-methods
     enable_hw_checksum: bool = True
 
     @model_validator(mode="after")
-    @classmethod
-    def validate_upf_mode_with_mac_addresses(cls, values):
+    def validate_upf_mode_with_mac_addresses(self):
         """Validate that MAC addresses are defined when in DPDK mode."""
-        if values.upf_mode == "dpdk":
+        if self.upf_mode == "dpdk":
             invalid_configs = []
-            if not values.access_interface_mac_address:
+            if not self.access_interface_mac_address:
                 invalid_configs.append("access-interface-mac-address")
-            if not values.core_interface_mac_address:
+            if not self.core_interface_mac_address:
                 invalid_configs.append("core-interface-mac-address")
             if invalid_configs:
                 raise ValueError(" ".join(invalid_configs))
-        return values
+        return self
 
     @field_validator("access_ip", "core_ip", mode="before")
     @classmethod

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -16,8 +16,8 @@ from pydantic import (  # pylint: disable=no-name-in-module,import-error
     Field,
     StrictStr,
     ValidationError,
+    ValidationInfo,
 )
-from pydantic import ValidationInfo
 from pydantic.functional_validators import field_validator, model_validator
 from pydantic.networks import IPvAnyAddress, IPvAnyNetwork
 from pydantic_extra_types.mac_address import MacAddress
@@ -107,6 +107,7 @@ class UpfConfig(BaseModel):  # pylint: disable=too-few-public-methods
         """Validate that IP network address is valid."""
         ip_network(value, strict=False)
         return value
+
 
 @dataclasses.dataclass(frozen=True)
 class CharmConfig:

--- a/src/charm_state.py
+++ b/src/charm_state.py
@@ -1,0 +1,159 @@
+# Copyright 2024 Canonical Ltd.
+# See LICENSE file for licensing details.
+
+"""State of the Charm."""
+
+import dataclasses
+import logging
+from enum import Enum
+from ipaddress import IPv4Network, IPv6Network
+from typing import Optional
+
+import ops
+from pydantic import (  # pylint: disable=no-name-in-module,import-error
+    BaseModel,
+    ConfigDict,
+    Field,
+    StrictStr,
+    ValidationError,
+)
+from pydantic.functional_validators import model_validator
+from pydantic.networks import IPvAnyAddress, IPvAnyNetwork
+from pydantic_core import PydanticCustomError
+from pydantic_extra_types.mac_address import MacAddress
+from typing_extensions import TypeAlias
+
+logger = logging.getLogger(__name__)
+
+
+class CNIType(str, Enum):
+    """Class to define available CNI types for UPF operator."""
+
+    bridge = "bridge"
+    macvlan = "macvlan"
+    dpdk = "dpdk"
+    host_device = "host-device"
+
+
+class UpfMode(str, Enum):
+    """Class to define available UPF modes for UPF operator."""
+
+    af_packet = "af_packet"
+    dpdk = "dpdk"
+
+
+NetworkType: TypeAlias = "str | bytes | int | tuple[str | bytes | int, str | int]"
+
+
+class LaxIPvAnyNetwork(IPvAnyNetwork):
+    """Validate an IPv4 or IPv6 network."""
+
+    def __new__(cls, value: NetworkType):
+        """Validate an IPv4 or IPv6 network."""
+        # Assume IP Network is defined with a default value for `strict` argument.
+        # Define your own class if you want to specify network address check strictness.
+        try:
+            return IPv4Network(value, strict=False)
+        except ValueError:
+            pass
+
+        try:
+            return IPv6Network(value, strict=False)
+        except ValueError:
+            raise PydanticCustomError(
+                "ip_any_network", "value is not a valid IPv4 or IPv6 network"
+            )
+
+
+class CharmConfigInvalidError(Exception):
+    """Exception raised when a charm configuration is found to be invalid.
+
+    Attrs:
+        msg (str): Explanation of the error.
+    """
+
+    def __init__(self, msg: str):
+        """Initialize a new instance of the CharmConfigInvalidError exception.
+
+        Args:
+            msg (str): Explanation of the error.
+        """
+        self.msg = msg
+
+
+def to_kebab(name: str) -> str:
+    """Converts a snake_case string to kebab-case."""
+    return name.replace("_", "-")
+
+
+class UpfConfig(BaseModel):  # pylint: disable=too-few-public-methods
+    """Represent UPF operator builtin configuration values."""
+
+    model_config = ConfigDict(alias_generator=to_kebab, use_enum_values=True)
+
+    cni_type: CNIType
+    upf_mode: UpfMode = UpfMode.af_packet
+    dnn: StrictStr = Field(default="internet", min_length=1)
+    gnb_subnet: LaxIPvAnyNetwork = LaxIPvAnyNetwork("192.168.251.0/24")
+    access_interface: Optional[StrictStr] = Field(default="")
+    access_interface_mac_address: MacAddress = Field(default=None)
+    access_ip: LaxIPvAnyNetwork = LaxIPvAnyNetwork("192.168.252.3/24")
+    access_gateway_ip: IPvAnyAddress = IPvAnyAddress("192.168.252.1")
+    access_interface_mtu_size: Optional[int] = Field(
+        default=None, ge=1200, le=65535, validate_default=True
+    )
+    core_interface: Optional[StrictStr] = Field(default="")
+    core_interface_mac_address: MacAddress = Field(default=None)
+    core_ip: LaxIPvAnyNetwork = LaxIPvAnyNetwork("192.168.250.3/24")
+    core_gateway_ip: IPvAnyAddress = IPvAnyAddress("192.168.250.1")
+    core_interface_mtu_size: Optional[int] = Field(default=None, ge=1200, le=65535)
+    external_upf_hostname: Optional[StrictStr] = Field(default="")
+    vlan_id: Optional[int] = Field(default=None, ge=1, le=4095)
+    enable_hw_checksum: bool = True
+
+    @model_validator(mode="after")
+    @classmethod
+    def validate_upf_mode_with_mac_addresses(cls, values):
+        """Validate that MAC addresses are defined when in DPDK mode."""
+        if values.upf_mode == "dpdk":
+            invalid_configs = []
+            if not values.access_interface_mac_address:
+                invalid_configs.append("access-interface-mac-address")
+            if not values.core_interface_mac_address:
+                invalid_configs.append("core-interface-mac-address")
+            if invalid_configs:
+                raise ValueError(" ".join(invalid_configs))
+        return values
+
+
+@dataclasses.dataclass(frozen=True)
+class CharmState:
+    """State of the Charm."""
+
+    upf_config: UpfConfig
+
+    @classmethod
+    def from_charm(
+        cls,
+        charm: ops.CharmBase,
+    ) -> "CharmState":
+        """Initialize a new instance of the CharmState class from the associated charm."""
+        try:
+            # ignoring because mypy fails with:
+            # "has incompatible type "**dict[str, str]"; expected ...""
+            valid_upf_config = UpfConfig(**dict(charm.config.items()))  # type: ignore
+        except ValidationError as exc:
+            error_fields: list = []
+            for error in exc.errors():
+                if param := error["loc"]:
+                    error_fields.extend(param)
+                else:
+                    value_error_msg: ValueError = error["ctx"]["error"]
+                    error_fields.extend(str(value_error_msg).split())
+            error_fields.sort()
+            error_field_str = ", ".join(f"'{f}'" for f in error_fields)
+            raise CharmConfigInvalidError(
+                f"The following configurations are not valid: [{error_field_str}]"
+            ) from exc
+
+        return cls(upf_config=valid_upf_config)

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -885,6 +885,7 @@ class TestCharm(unittest.TestCase):
                 "core-interface": CORE_INTERFACE_NAME,
                 "core-ip": VALID_CORE_IP,
                 "core-gateway-ip": CORE_GW_IP,
+                "cni-type": "macvlan",
             }
         )
         nads = self.harness.charm._network_attachment_definitions_from_config()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -952,6 +952,7 @@ class TestCharm(unittest.TestCase):
                 "cni-type": "macvlan",
             }
         )
+        self.reinstantiate_charm()
         nads = self.harness.charm._network_attachment_definitions_from_config()
         for nad in nads:
             config = json.loads(nad.spec["config"])

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1625,7 +1625,14 @@ class TestCharm(unittest.TestCase):
         patch_hugepages_is_patched.return_value = False
         patched_check_output.return_value = b"Flags: ssse3 fma cx16 rdrand"
 
-        self.harness.update_config(key_values={"enable-hugepages": True})
+        self.harness.update_config(
+            key_values={
+                "cni-type": "vfioveth",
+                "upf-mode": "dpdk",
+                "access-interface-mac-address": "00-B0-D0-63-C2-26",
+                "core-interface-mac-address": "00-B0-D0-63-C2-26",
+            }
+        )
         self.reinstantiate_charm()
 
         self.assertEqual(
@@ -1826,6 +1833,10 @@ class TestCharm(unittest.TestCase):
             ),
         )
 
+    @patch(
+        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
+        Mock(return_value=True),
+    )
     def test_given_default_config_with_interfaces_zero_mtu_sizes_when_network_attachment_definitions_from_config_is_called_then_status_is_blocked(  # noqa: E501
         self,
     ):
@@ -1835,6 +1846,7 @@ class TestCharm(unittest.TestCase):
                 "core-interface-mtu-size": ZERO_MTU_SIZE,
             }
         )
+        self.reinstantiate_charm()
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus(
@@ -1967,6 +1979,7 @@ class TestCharm(unittest.TestCase):
     ):
         self.harness.handle_exec("bessd", [], result=0)
         self.harness.update_config(key_values={"enable-hw-checksum": False})
+        self.reinstantiate_charm()
         self.harness.container_pebble_ready(container_name="bessd")
 
         config = json.loads((self.root / "etc/bess/conf/upf.json").read_text())

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -815,7 +815,6 @@ class TestCharm(unittest.TestCase):
             upf_n4_port=TEST_PFCP_PORT,
         )
 
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.get")
     @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
     @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
@@ -841,7 +840,6 @@ class TestCharm(unittest.TestCase):
             upf_n4_port=TEST_PFCP_PORT,
         )
 
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.get")
     @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
     @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
@@ -861,7 +859,6 @@ class TestCharm(unittest.TestCase):
             upf_n4_port=TEST_PFCP_PORT,
         )
 
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.get")
     @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
     @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
@@ -964,7 +961,6 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.Client.create")
     @patch("ops.model.Container.get_service")
     @patch("lightkube.core.client.Client.list")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
@@ -997,7 +993,6 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.Client.create")
     @patch("ops.model.Container.get_service")
     @patch("lightkube.core.client.Client.list")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
@@ -1035,7 +1030,6 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.Client.create")
     @patch("ops.model.Container.get_service")
     @patch("lightkube.core.client.Client.list")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
@@ -1091,7 +1085,6 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.Client.create")
     @patch("ops.model.Container.get_service")
     @patch("lightkube.core.client.Client.list")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
@@ -1145,7 +1138,6 @@ class TestCharm(unittest.TestCase):
 
     @patch("lightkube.core.client.Client.patch")
     @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
@@ -1179,7 +1171,6 @@ class TestCharm(unittest.TestCase):
 
     @patch("lightkube.core.client.Client.patch")
     @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
@@ -1223,7 +1214,6 @@ class TestCharm(unittest.TestCase):
 
     @patch("lightkube.core.client.Client.patch")
     @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
@@ -1267,7 +1257,6 @@ class TestCharm(unittest.TestCase):
 
     @patch("lightkube.core.client.Client.patch")
     @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
@@ -1311,7 +1300,6 @@ class TestCharm(unittest.TestCase):
 
     @patch("lightkube.core.client.Client.patch")
     @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
@@ -1356,7 +1344,6 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.Client.patch")
     @patch("ops.model.Container.get_service")
     @patch("lightkube.core.client.Client.list")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
@@ -1403,7 +1390,6 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.Client.patch")
     @patch("ops.model.Container.get_service")
     @patch("lightkube.core.client.Client.list")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
@@ -1463,7 +1449,6 @@ class TestCharm(unittest.TestCase):
     @patch("lightkube.core.client.Client.patch")
     @patch("ops.model.Container.get_service")
     @patch("lightkube.core.client.Client.list")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
@@ -1585,7 +1570,6 @@ class TestCharm(unittest.TestCase):
 
     @patch("lightkube.core.client.Client.create")
     @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
@@ -1641,7 +1625,6 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.list")
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     @patch("dpdk.DPDK.is_configured")
@@ -1676,7 +1659,6 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.list")
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_cpu_supporting_required_hugepages_instructions_and_not_available_hugepages_when_hugepages_enabled_then_charm_goes_to_blocked_status(  # noqa: E501
@@ -1700,7 +1682,6 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch("lightkube.core.client.Client.list")
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     @patch("dpdk.DPDK.is_configured")
@@ -1742,7 +1723,6 @@ class TestCharm(unittest.TestCase):
         )
 
     @patch("charm.check_output")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.multus_is_available")
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_multus_disabled_then_enabled_when_update_status_then_status_is_active(
@@ -1784,7 +1764,6 @@ class TestCharm(unittest.TestCase):
 
     @patch("lightkube.core.client.Client.create")
     @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.GenericSyncClient", new=Mock)
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -121,7 +121,7 @@ class TestCharm(unittest.TestCase):
             [],
             [],
         ]
-        self.harness.update_config(key_values={"cni-type": "dpdk", "upf-mode": "dpdk"})
+        self.harness.update_config(key_values={"cni-type": "vfioveth", "upf-mode": "dpdk"})
 
         self.assertEqual(
             self.harness.model.unit.status,
@@ -142,7 +142,7 @@ class TestCharm(unittest.TestCase):
             [],
             [],
         ]
-        self.harness.update_config(key_values={"cni-type": "dpdk", "upf-mode": "dpdk"})
+        self.harness.update_config(key_values={"cni-type": "vfioveth", "upf-mode": "dpdk"})
 
         self.assertEqual(
             self.harness.model.unit.status,
@@ -165,7 +165,7 @@ class TestCharm(unittest.TestCase):
         ]
         self.harness.update_config(
             key_values={
-                "cni-type": "dpdk",
+                "cni-type": "vfioveth",
                 "upf-mode": "dpdk",
                 "access-interface-mac-address": INVALID_ACCESS_MAC,
                 "core-interface-mac-address": VALID_CORE_MAC,
@@ -193,7 +193,7 @@ class TestCharm(unittest.TestCase):
         ]
         self.harness.update_config(
             key_values={
-                "cni-type": "dpdk",
+                "cni-type": "vfioveth",
                 "upf-mode": "dpdk",
                 "access-interface-mac-address": VALID_ACCESS_MAC,
                 "core-interface-mac-address": INVALID_CORE_MAC,
@@ -917,7 +917,7 @@ class TestCharm(unittest.TestCase):
         ]
         self.harness.update_config(
             key_values={
-                "cni-type": "dpdk",
+                "cni-type": "vfioveth",
                 "upf-mode": "dpdk",
                 "access-interface-mac-address": VALID_ACCESS_MAC,
                 "core-interface-mac-address": VALID_CORE_MAC,
@@ -950,7 +950,7 @@ class TestCharm(unittest.TestCase):
         ]
         self.harness.update_config(
             key_values={
-                "cni-type": "dpdk",
+                "cni-type": "vfioveth",
                 "upf-mode": "dpdk",
                 "access-interface-mac-address": VALID_ACCESS_MAC,
                 "core-interface-mac-address": VALID_CORE_MAC,
@@ -988,7 +988,7 @@ class TestCharm(unittest.TestCase):
         ]
         self.harness.update_config(
             key_values={
-                "cni-type": "dpdk",
+                "cni-type": "vfioveth",
                 "upf-mode": "dpdk",
                 "access-interface-mac-address": VALID_ACCESS_MAC,
                 "core-interface-mac-address": VALID_CORE_MAC,
@@ -1044,7 +1044,7 @@ class TestCharm(unittest.TestCase):
         ]
         self.harness.update_config(
             key_values={
-                "cni-type": "dpdk",
+                "cni-type": "vfioveth",
                 "upf-mode": "dpdk",
                 "access-interface-mac-address": VALID_ACCESS_MAC,
                 "core-interface-mac-address": VALID_CORE_MAC,
@@ -1309,7 +1309,7 @@ class TestCharm(unittest.TestCase):
         ]
         self.harness.update_config(
             key_values={
-                "cni-type": "dpdk",
+                "cni-type": "vfioveth",
                 "upf-mode": "dpdk",
                 "access-interface-mac-address": VALID_ACCESS_MAC,
                 "core-interface-mac-address": VALID_CORE_MAC,
@@ -1356,7 +1356,7 @@ class TestCharm(unittest.TestCase):
         ]
         self.harness.update_config(
             key_values={
-                "cni-type": "dpdk",
+                "cni-type": "vfioveth",
                 "upf-mode": "dpdk",
                 "access-ip": VALID_ACCESS_IP,
                 "access-interface-mac-address": VALID_ACCESS_MAC,
@@ -1416,7 +1416,7 @@ class TestCharm(unittest.TestCase):
         ]
         self.harness.update_config(
             key_values={
-                "cni-type": "dpdk",
+                "cni-type": "vfioveth",
                 "upf-mode": "dpdk",
                 "core-ip": VALID_CORE_IP,
                 "access-interface-mac-address": VALID_ACCESS_MAC,
@@ -1588,7 +1588,7 @@ class TestCharm(unittest.TestCase):
 
         self.harness.update_config(
             key_values={
-                "cni-type": "dpdk",
+                "cni-type": "vfioveth",
                 "upf-mode": "dpdk",
                 "access-interface-mac-address": "00-B0-D0-63-C2-26",
                 "core-interface-mac-address": "00-B0-D0-63-C2-26",
@@ -1613,7 +1613,7 @@ class TestCharm(unittest.TestCase):
 
         self.harness.update_config(
             key_values={
-                "cni-type": "dpdk",
+                "cni-type": "vfioveth",
                 "upf-mode": "dpdk",
                 "access-interface-mac-address": "00-B0-D0-63-C2-26",
                 "core-interface-mac-address": "00-B0-D0-63-C2-26",
@@ -1648,7 +1648,7 @@ class TestCharm(unittest.TestCase):
 
         self.harness.update_config(
             key_values={
-                "cni-type": "dpdk",
+                "cni-type": "vfioveth",
                 "upf-mode": "dpdk",
                 "access-interface-mac-address": "00-B0-D0-63-C2-26",
                 "core-interface-mac-address": "00-B0-D0-63-C2-26",


### PR DESCRIPTION
# Description

This PR aims to leverage Pydantic to validate charm config input parameters.
Support for `host-device` CNI type is added.
Config option `enable-hugepages` is removed and it is inferred from `upf-mode`.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
