### PR TITLE
fix: TELCO-996 Use blocked status instead of throwing exception

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -66,12 +66,6 @@ SUPPORTED_UPF_MODES = ["af_packet", "dpdk"]
 DEFAULT_FIELD_MANAGER = "controller"
 
 
-class IncompatibleCPUError(Exception):
-    """Custom error to be raised when CPU doesn't support required instructions."""
-
-    pass
-
-
 class NadConfigChangedEvent(EventBase):
     """Event triggered when an existing network attachment definition is changed."""
 
@@ -213,12 +207,8 @@ class UPFOperatorCharm(CharmBase):
         Args:
             event: Juju event
         """
-        if not self._is_cpu_compatible():
-            raise IncompatibleCPUError(
-                "\nCPU is not compatible!\n"
-                "Please use a CPU that has the following capabilities: "
-                f"{', '.join(REQUIRED_CPU_EXTENSIONS)}"
-            )
+        if not self._cpu_check():
+            return
         self._create_external_upf_service()
 
     def _on_fiveg_n3_request(self, event: EventBase) -> None:
@@ -480,16 +470,9 @@ class UPFOperatorCharm(CharmBase):
         """Handler for config changed events."""
         if not self.unit.is_leader():
             return
-        if self._hugepages_is_enabled():
-            if not self._cpu_is_compatible_for_hugepages():
-                raise IncompatibleCPUError(
-                    "\nCPU is not compatible!\n"
-                    "Please use a CPU that has the following capabilities: "
-                    f"{', '.join(REQUIRED_CPU_EXTENSIONS + REQUIRED_CPU_EXTENSIONS_HUGEPAGES)}"
-                )
-            if not self._hugepages_are_available():
-                self.unit.status = BlockedStatus("Not enough HugePages available")
-                return
+
+        if not self._cpu_check():
+            return
         if not self._kubernetes_multus.multus_is_available():
             self.unit.status = BlockedStatus("Multus is not installed or enabled")
             return
@@ -509,14 +492,37 @@ class UPFOperatorCharm(CharmBase):
         self._update_fiveg_n3_relation_data()
         self._update_fiveg_n4_relation_data()
 
+    def _cpu_check(self):
+        if not self._is_cpu_compatible():
+            logger.info("Blocked!")
+            self.unit.status = BlockedStatus(
+                "Please use a CPU that has the following capabilities: "
+                f"{', '.join(REQUIRED_CPU_EXTENSIONS)}"
+            )
+            return False
+        if self._hugepages_is_enabled():
+            if not self._cpu_is_compatible_for_hugepages():
+                self.unit.status = BlockedStatus(
+                    "Please use a CPU that has the following capabilities: "
+                    f"{', '.join(REQUIRED_CPU_EXTENSIONS + REQUIRED_CPU_EXTENSIONS_HUGEPAGES)}"
+                )
+                return False
+            if not self._hugepages_are_available():
+                self.unit.status = BlockedStatus("Not enough HugePages available")
+                return False
+        return True
+
     def _on_bessd_pebble_ready(self, event: EventBase) -> None:
         """Handle Pebble ready event."""
         if not self.unit.is_leader():
             return
+
         if invalid_configs := self._get_invalid_configs():
             self.unit.status = BlockedStatus(
                 f"The following configurations are not valid: {invalid_configs}"
             )
+            return
+        if not self._cpu_check():
             return
         if not self._kubernetes_multus.is_ready():
             self.unit.status = WaitingStatus("Waiting for Multus to be ready")
@@ -530,6 +536,8 @@ class UPFOperatorCharm(CharmBase):
     def _on_pfcp_agent_pebble_ready(self, event: EventBase) -> None:
         """Handle pfcp agent Pebble ready event."""
         if not self.unit.is_leader():
+            return
+        if not self._cpu_check():
             return
         if not service_is_running_on_container(self._bessd_container, self._bessd_service_name):
             self.unit.status = WaitingStatus("Waiting for bessd service to run")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1542,7 +1542,7 @@ class TestCharm(unittest.TestCase):
     @patch("charm.check_output")
     @patch("charm.Client", new=Mock)
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    def test_given_cpu_not_supporting_required_hugepages_instructions_when_hugepages_enabled_then_incompatiblecpuerror_is_raised(  # noqa: E501
+    def test_given_cpu_not_supporting_required_hugepages_instructions_when_hugepages_enabled_then_charm_goes_to_blocked_status(  # noqa: E501
         self, patch_hugepages_is_patched, patched_check_output
     ):
         patch_hugepages_is_patched.return_value = False


### PR DESCRIPTION
# Description

Instead of using an exception, which results in messages that are not helpful to the user (ie: hook failed), this change puts the charm into blocked state instead.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- N/A I have made corresponding changes to the documentation
- [X] I have added tests that validate the behaviour of the software
- [X] I validated that new and existing unit tests pass locally with my changes
- N/A Any dependent changes have been merged and published in downstream modules
- N/A I have bumped the version of the library
