### PR TITLE
chore: Remove residual getter

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -333,7 +333,7 @@ class UPFOperatorCharm(CharmBase):
             NetworkAttachmentDefinition: NetworkAttachmentDefinition object
         """
         nad_config = self._get_nad_base_config()
-        cni_type = self._get_cni_type_config()
+        cni_type = self._charm_config.cni_type
         # MTU is optional for bridge, macvlan, dpdk
         # MTU is ignored by host-device
         if cni_type != CNIType.host_device:
@@ -924,9 +924,6 @@ class UPFOperatorCharm(CharmBase):
             return self._charm_config.core_interface_mtu_size
         else:
             return None
-
-    def _get_cni_type_config(self) -> Optional[str]:
-        return self._charm_config.cni_type
 
     def _hugepages_is_enabled(self) -> bool:
         """Returns whether HugePages are enabled.


### PR DESCRIPTION
# Description

This PR aims to remove one useless getter function, residual from the introduction of Pydantic validation.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
