### PR TITLE
fix: Using charm name as DEFAULT_FIELD_MANAGER

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -63,9 +63,6 @@ REQUIRED_CPU_EXTENSIONS = ["avx2", "rdrand"]
 REQUIRED_CPU_EXTENSIONS_HUGEPAGES = ["pdpe1gb"]
 LOGGING_RELATION_NAME = "logging"
 
-# The default field manager set when using kubectl to create resources
-DEFAULT_FIELD_MANAGER = "controller"
-
 
 class NadConfigChangedEvent(EventBase):
     """Event triggered when an existing network attachment definition is changed."""
@@ -170,7 +167,7 @@ class UPFOperatorCharm(CharmBase):
             ),
         )
 
-        client.apply(service, field_manager=DEFAULT_FIELD_MANAGER)
+        client.apply(service, field_manager=self.model.app.name)
         logger.info("Created/asserted existence of the external UPF service")
 
     def _on_remove(self, event: RemoveEvent) -> None:

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1558,7 +1558,7 @@ class TestCharm(unittest.TestCase):
         )
 
         patch_client.return_value.apply.assert_called_once_with(
-            expected_service, field_manager="controller"
+            expected_service, field_manager="sdcore-upf-k8s"
         )
 
     @patch("charm.Client")


### PR DESCRIPTION
# Description

The global constant called DEFAULT_FIELD_MANAGER is set to a default value which is `controller` refers the name of Juju controller that is not always correct.  Replacing  DEFAULT_FIELD_MANAGER with the charm name as it is the charm in charge of managing the field.


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
