### PR TITLE
chore: Using default, 30s timeout for up4 config instead of 300s

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -602,7 +602,6 @@ class UPFOperatorCharm(CharmBase):
                     logger.info("Starting configuration of the `bessd` service")
                     self._exec_command_in_bessd_workload(
                         command="/opt/bess/bessctl/bessctl run /opt/bess/bessctl/conf/up4",
-                        timeout=timeout,
                         environment=self._bessd_environment_variables,
                     )
                     message = "Service `bessd` configured"

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -555,7 +555,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready(container_name="bessd")
 
         self.assertTrue(bessctl_called)
-        self.assertEqual(timeout, 300)
+        self.assertEqual(timeout, 30)
         self.assertEqual(
             environment, {"CONF_FILE": "/etc/bess/conf/upf.json", "PYTHONPATH": "/opt/bess"}
         )
@@ -612,7 +612,7 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready(container_name="bessd")
 
         self.assertTrue(bessctl_called)
-        self.assertEqual(timeout, 300)
+        self.assertEqual(timeout, 30)
         self.assertEqual(
             environment, {"CONF_FILE": "/etc/bess/conf/upf.json", "PYTHONPATH": "/opt/bess"}
         )


### PR DESCRIPTION
# Description

If the `_exec_command_in_bessd_workload` timeout is the same as the timeout of the outer `while`, if the command hangs, it will never be retried.

NOTE:
Commands in the `up4.bess` script are not thread-safe, so after this change, the retry may fail anyway. Despite multiple tries, I wasn't able to provoke the command to hang. CI seems to be pretty good at it, hence the PR.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
