### PR TITLE
chore: handle charm status with ops CollectStatus event

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -551,6 +551,8 @@ class UPFOperatorCharm(CharmBase):
         """Handle pfcp agent Pebble ready event."""
         if self._check_cpu_compatibility():
             return
+        if self._unit_is_non_active_status():
+            return
         self._configure_pfcp_agent_workload()
 
     def _configure_bessd_workload(self) -> None:

--- a/src/charm.py
+++ b/src/charm.py
@@ -93,12 +93,8 @@ class UPFOperatorCharm(CharmBase):
 
     def __init__(self, *args):
         super().__init__(*args)
+        self.framework.observe(self.on.collect_unit_status, self._on_collect_unit_status)
         if not self.unit.is_leader():
-            # NOTE: In cases where leader status is lost before the charm is
-            # finished processing all teardown events, this prevents teardown
-            # event code from running. Luckily, for this charm, none of the
-            # teardown code is necessary to perform if we're removing the
-            # charm.
             return
         self._bessd_container_name = self._bessd_service_name = "bessd"
         self._routectl_service_name = "routectl"

--- a/src/charm.py
+++ b/src/charm.py
@@ -524,11 +524,11 @@ class UPFOperatorCharm(CharmBase):
         if not self._bessd_container.exists(path=BESSD_CONTAINER_CONFIG_PATH):
             logger.info("Waiting for storage to be attached")
             return WaitingStatus("Waiting for storage to be attached")
-        if container_status := self._container_services_are_running():
+        if container_status := self._unavailable_container_services():
             return container_status
         return None
 
-    def _container_services_are_running(self) -> Optional[WaitingStatus]:
+    def _unavailable_container_services(self) -> Optional[WaitingStatus]:
         """Returns status representation of container services availability.
 
         Returns:

--- a/src/charm.py
+++ b/src/charm.py
@@ -31,14 +31,7 @@ from lightkube.core.client import Client
 from lightkube.models.core_v1 import ServicePort, ServiceSpec
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Node, Pod, Service
-from ops import (
-    ActiveStatus,
-    BlockedStatus,
-    Container,
-    ModelError,
-    RemoveEvent,
-    WaitingStatus,
-)
+from ops import ActiveStatus, BlockedStatus, Container, ModelError, RemoveEvent, WaitingStatus
 from ops.charm import CharmBase, CharmEvents, CollectStatusEvent
 from ops.framework import EventBase, EventSource
 from ops.main import main

--- a/src/charm.py
+++ b/src/charm.py
@@ -586,7 +586,6 @@ class UPFOperatorCharm(CharmBase):
         if not self._hugepages_are_available():
             return
         if not service_is_running_on_container(self._bessd_container, self._bessd_service_name):
-            event.defer()
             return
         self._configure_pfcp_agent_workload()
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -509,6 +509,8 @@ class UPFOperatorCharm(CharmBase):
             return WaitingStatus("Waiting for Multus to be ready")
         if not self._bessd_container.exists(path=BESSD_CONTAINER_CONFIG_PATH):
             return WaitingStatus("Waiting for storage to be attached")
+        if status := self._check_container_availability():
+            return status
 
     def _check_container_availability(self):
         if not service_is_running_on_container(self._bessd_container, self._bessd_service_name):

--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -28,7 +28,6 @@ async def _deploy_grafana_agent(ops_test: OpsTest):
 
 
 @pytest.fixture(scope="module")
-@pytest.mark.abort_on_fail
 async def build_and_deploy(ops_test):
     """Build the charm-under-test and deploy it."""
     charm = await ops_test.build_charm(".")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1794,7 +1794,8 @@ class TestCharm(unittest.TestCase):
         self.harness.evaluate_status()
 
         self.assertEqual(
-            self.harness.model.unit.status, BlockedStatus("CPU is not compatible, see logs for more details")
+            self.harness.model.unit.status,
+            BlockedStatus("CPU is not compatible, see logs for more details"),
         )
 
     @patch("charm.check_output")
@@ -1831,7 +1832,8 @@ class TestCharm(unittest.TestCase):
         self.harness.evaluate_status()
 
         self.assertEqual(
-            self.harness.model.unit.status, BlockedStatus("CPU is not compatible, see logs for more details")
+            self.harness.model.unit.status,
+            BlockedStatus("CPU is not compatible, see logs for more details"),
         )
 
         self.harness.charm.on.update_status.emit()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -698,18 +698,22 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     @patch("ops.model.Container.get_service")
     def test_given_bessd_service_is_running_when_pfcp_agent_pebble_ready_then_pebble_plan_is_applied(  # noqa: E501
         self,
         patch_get_service,
+        patch_multus_is_ready,
     ):
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
         patch_get_service.return_value = service_info_mock
+        patch_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
 
         self.harness.container_pebble_ready(container_name="pfcp-agent")
         self.harness.evaluate_status()
+        self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
 
         expected_plan = {
             "services": {

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1745,6 +1745,7 @@ class TestCharm(unittest.TestCase):
         patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
         patch_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
+            [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1024,6 +1024,7 @@ class TestCharm(unittest.TestCase):
         patch_get_service.return_value = service_info_mock
         patched_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
+            [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
             [],
@@ -1099,6 +1100,7 @@ class TestCharm(unittest.TestCase):
         patch_get_service.return_value = service_info_mock
         patched_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
+            [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
             [],
@@ -1156,6 +1158,7 @@ class TestCharm(unittest.TestCase):
         service_info_mock.is_running.return_value = True
         patch_get_service.return_value = service_info_mock
         patched_list.side_effect = [
+            [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
@@ -1435,6 +1438,7 @@ class TestCharm(unittest.TestCase):
         patch_get_service.return_value = service_info_mock
         patched_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
+            [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
             [],
@@ -1484,6 +1488,7 @@ class TestCharm(unittest.TestCase):
         service_info_mock.is_running.return_value = True
         patch_get_service.return_value = service_info_mock
         patched_list.side_effect = [
+            [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
@@ -1548,6 +1553,7 @@ class TestCharm(unittest.TestCase):
         patch_get_service.return_value = service_info_mock
         patched_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
+            [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
             [],
@@ -1602,7 +1608,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("CPU is not compatible, see logs"),
+            BlockedStatus("CPU is not compatible, see logs for more details"),
         )
 
     @patch("charm.check_output")
@@ -1726,7 +1732,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("CPU is not compatible, see logs"),
+            BlockedStatus("CPU is not compatible, see logs for more details"),
         )
 
     @patch("charm.check_output")
@@ -1744,6 +1750,7 @@ class TestCharm(unittest.TestCase):
         patch_hugepages_is_patched.return_value = True
         patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
         patch_list.side_effect = [
+            [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1787,7 +1794,7 @@ class TestCharm(unittest.TestCase):
         self.harness.evaluate_status()
 
         self.assertEqual(
-            self.harness.model.unit.status, BlockedStatus("Not enough HugePages available")
+            self.harness.model.unit.status, BlockedStatus("CPU is not compatible, see logs for more details")
         )
 
     @patch("charm.check_output")
@@ -1824,7 +1831,7 @@ class TestCharm(unittest.TestCase):
         self.harness.evaluate_status()
 
         self.assertEqual(
-            self.harness.model.unit.status, BlockedStatus("Not enough HugePages available")
+            self.harness.model.unit.status, BlockedStatus("CPU is not compatible, see logs for more details")
         )
 
         self.harness.charm.on.update_status.emit()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -275,11 +275,16 @@ class TestCharm(unittest.TestCase):
             ),
         )
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bessd_config_file_not_yet_written_when_bessd_pebble_ready_then_config_file_is_written(  # noqa: E501
-        self, _
+        self,
+        _,
+        __,
     ):
         self.harness.handle_exec("bessd", [], result=0)
+        self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.container_pebble_ready(container_name="bessd")
         expected_config_file_content = read_file("tests/unit/expected_upf.json").strip()
 
@@ -287,12 +292,14 @@ class TestCharm(unittest.TestCase):
             (self.root / "etc/bess/conf/upf.json").read_text(), expected_config_file_content
         )
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bessd_config_file_not_yet_written_when_config_storage_attached_then_config_file_is_written(  # noqa: E501
-        self, _
+        self, _, __
     ):
         self.harness.handle_exec("bessd", [], result=0)
         self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         (self.root / "etc/bess/conf").rmdir()
         self.harness.add_storage(storage_name="config", count=1)
         self.harness.attach_storage(storage_id="config/0")
@@ -317,12 +324,16 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual((self.root / "etc/bess/conf/upf.json").read_text(), expected_upf_content)
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_when_bessd_pebble_ready_then_expected_pebble_plan_is_applied(  # noqa: E501
         self,
         patch_is_ready,
+        _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
+        self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         patch_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
@@ -360,10 +371,13 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(expected_plan, updated_plan)
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_can_connect_to_bessd_when_bessd_pebble_ready_then_ip_route_is_created(
-        self, patch_is_ready
+        self, patch_is_ready, _
     ):
+        self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         ip_route_replace_called = False
         timeout = 0
         environment = {}
@@ -401,10 +415,13 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(timeout, 30)
         self.assertEqual(environment, {})
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_can_connect_to_bessd_when_bessd_pebble_ready_then_gnb_subnet_route_is_created(
-        self, patch_is_ready
+        self, patch_is_ready, _
     ):
+        self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         gnb_subnet_route_replace_called = False
         timeout = 0
         environment = {}
@@ -442,10 +459,13 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(timeout, 30)
         self.assertEqual(environment, {})
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_iptables_rule_is_not_yet_created_when_bessd_pebble_ready_then_rule_is_created(
-        self, patch_is_ready
+        self, patch_is_ready, _
     ):
+        self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         iptables_drop_called = False
         timeout = 0
         environment = {}
@@ -493,10 +513,13 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(timeout, 30)
         self.assertEqual(environment, {})
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_iptables_rule_is_created_when_bessd_pebble_ready_then_rule_is_not_re_created(
-        self, patch_is_ready
+        self, patch_is_ready, _
     ):
+        self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         iptables_drop_called = False
 
         iptables_drop_cmd = [
@@ -526,10 +549,13 @@ class TestCharm(unittest.TestCase):
 
         self.assertFalse(iptables_drop_called)
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_can_connect_to_bessd_when_bessd_pebble_ready_then_bessctl_configure_is_executed(
-        self, patch_is_ready
+        self, patch_is_ready, _
     ):
+        self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         bessctl_called = False
         timeout = 0
         environment = {}
@@ -558,10 +584,13 @@ class TestCharm(unittest.TestCase):
             environment, {"CONF_FILE": "/etc/bess/conf/upf.json", "PYTHONPATH": "/opt/bess"}
         )
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_connects_and_bessctl_executed_file_exists_then_bessctl_configure_not_executed(
-        self, patch_is_ready
+        self, patch_is_ready, _
     ):
+        self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         (self.root / "bessctl_configure_executed").write_text("")
 
         bessctl_called = False
@@ -582,10 +611,13 @@ class TestCharm(unittest.TestCase):
 
         self.assertFalse(bessctl_called)
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_connects_and_bessctl_executed_file_dont_exist_then_bessctl_configure_executed(
-        self, patch_is_ready
+        self, patch_is_ready, _
     ):
+        self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         bessctl_called = False
         timeout = 0
         environment = {}
@@ -737,6 +769,7 @@ class TestCharm(unittest.TestCase):
 
         patched_publish_upf_information.assert_not_called()
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
     @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
@@ -746,6 +779,7 @@ class TestCharm(unittest.TestCase):
         patch_multus_is_ready,
         patch_hugepages_is_patched,
         patched_publish_upf_information,
+        _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
         patch_multus_is_ready.return_value = True
@@ -884,6 +918,7 @@ class TestCharm(unittest.TestCase):
             upf_n4_port=TEST_PFCP_PORT,
         )
 
+    @patch("ops.model.Container.get_service")
     @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
@@ -893,6 +928,7 @@ class TestCharm(unittest.TestCase):
         patch_multus_is_ready,
         patch_hugepages_is_ready,
         patched_publish_upf_n4_information,
+        _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
         test_external_upf_hostname = "test-upf.external.hostname.com"
@@ -978,6 +1014,7 @@ class TestCharm(unittest.TestCase):
         self, patched_list, patch_get_service, kubernetes_create_object
     ):
         self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
         patch_get_service.return_value = service_info_mock
@@ -1012,6 +1049,7 @@ class TestCharm(unittest.TestCase):
         self, patched_list, patch_get_service, kubernetes_create_object
     ):
         self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
         patch_get_service.return_value = service_info_mock
@@ -1051,6 +1089,7 @@ class TestCharm(unittest.TestCase):
         self, patched_list, patch_get_service, kubernetes_create_object
     ):
         self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
         patch_get_service.return_value = service_info_mock
@@ -1108,6 +1147,7 @@ class TestCharm(unittest.TestCase):
         self, patched_list, patch_get_service, kubernetes_create_object
     ):
         self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
         patch_get_service.return_value = service_info_mock
@@ -1163,6 +1203,7 @@ class TestCharm(unittest.TestCase):
         self, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
@@ -1198,6 +1239,7 @@ class TestCharm(unittest.TestCase):
         self, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
@@ -1243,6 +1285,7 @@ class TestCharm(unittest.TestCase):
         self, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
@@ -1288,6 +1331,7 @@ class TestCharm(unittest.TestCase):
         self, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
@@ -1333,6 +1377,7 @@ class TestCharm(unittest.TestCase):
         self, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
@@ -1379,6 +1424,7 @@ class TestCharm(unittest.TestCase):
         self, patched_list, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
@@ -1428,6 +1474,7 @@ class TestCharm(unittest.TestCase):
         self, patched_list, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
@@ -1490,6 +1537,7 @@ class TestCharm(unittest.TestCase):
         self, patched_list, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
@@ -1896,6 +1944,7 @@ class TestCharm(unittest.TestCase):
             ),
         )
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
@@ -1907,6 +1956,7 @@ class TestCharm(unittest.TestCase):
         patch_delete_pod,
         patch_multus_is_ready,
         patch_list_na_definitions,
+        _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
         patch_hugepages_is_patched.return_value = True
@@ -1919,6 +1969,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_1})
         patch_delete_pod.assert_called_once()
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
@@ -1930,6 +1981,7 @@ class TestCharm(unittest.TestCase):
         patch_delete_pod,
         patch_multus_is_ready,
         patch_list_na_definitions,
+        _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
         patch_hugepages_is_patched.return_value = True
@@ -1946,6 +1998,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})
         self.assertEqual(patch_delete_pod.call_count, 2)
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
@@ -1957,6 +2010,7 @@ class TestCharm(unittest.TestCase):
         patch_delete_pod,
         patch_multus_is_ready,
         patch_list_na_definitions,
+        _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
         """Delete pod is called for the first config change, setting the same config value does not trigger pod restarts."""  # noqa: E501, W505
@@ -1986,6 +2040,7 @@ class TestCharm(unittest.TestCase):
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})
         patch_delete_pod.assert_called_once()
 
+    @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
@@ -1999,6 +2054,7 @@ class TestCharm(unittest.TestCase):
         patch_delete_pod,
         patch_multus_is_ready,
         patch_list_na_definitions,
+        _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
         patch_multus_is_ready.return_value = True
@@ -2011,15 +2067,20 @@ class TestCharm(unittest.TestCase):
         self.reinstantiate_charm()
         patch_delete_pod.assert_not_called()
 
+    @patch("ops.model.Container.get_service")
     @patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
     )
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_hardware_checksum_is_enabled_when_bessd_pebble_ready_then_config_file_has_hwcksum_enabled(  # noqa: E501
-        self, _
+        self,
+        _,
+        __,
     ):
         self.harness.handle_exec("bessd", [], result=0)
+        self.harness.set_can_connect("bessd", True)
+        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.update_config(key_values={"enable-hw-checksum": False})
         self.reinstantiate_charm()
         self.harness.container_pebble_ready(container_name="bessd")
@@ -2028,6 +2089,7 @@ class TestCharm(unittest.TestCase):
         self.assertIn("hwcksum", config)
         self.assertFalse(config["hwcksum"])
 
+    @patch("ops.model.Container.get_service")
     @patch("charm.UPFOperatorCharm.delete_pod")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
@@ -2036,6 +2098,7 @@ class TestCharm(unittest.TestCase):
         patch_hugepages_is_patched,
         patch_multus_is_ready,
         patch_delete_pod,
+        _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
         patch_hugepages_is_patched.return_value = True

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1602,7 +1602,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("Please use a CPU that has the following capabilities: avx2, rdrand"),
+            BlockedStatus("CPU is not compatible, see logs"),
         )
 
     @patch("charm.check_output")
@@ -1726,7 +1726,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("Please use a CPU that has the following capabilities: avx2, rdrand"),
+            BlockedStatus("CPU is not compatible, see logs"),
         )
 
     @patch("charm.check_output")


### PR DESCRIPTION
# Description

This PR aims to use new ops event `CollectStatus` to manage status in the charm. After the event named "collect_unit_status" (triggered after every hook), the callback sets the status of charm automatically.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
