### PR TITLE
chore: Catch ChangeError when configuring bess

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -36,7 +36,7 @@ from ops.charm import CharmBase, CharmEvents
 from ops.framework import EventBase, EventSource
 from ops.main import main
 from ops.model import ActiveStatus, BlockedStatus, Container, ModelError, WaitingStatus
-from ops.pebble import ExecError, Layer, PathError
+from ops.pebble import ChangeError, ExecError, Layer, PathError
 
 from charm_config import CharmConfig, CharmConfigInvalidError, CNIType, UpfMode
 from dpdk import DPDK
@@ -609,7 +609,7 @@ class UPFOperatorCharm(CharmBase):
                     self._create_bessctl_executed_validation_file(message)
                     return
                 return
-            except ExecError:
+            except (ChangeError, ExecError):
                 logger.info("Failed running configuration for bess")
                 time.sleep(2)
         raise TimeoutError("Timed out trying to run configuration for bess")


### PR DESCRIPTION
# Description

When `exec` (running command inside the container) command times out instead of failing, it raises `ChangeError` rather than the `ExecError`. 
This PR adds handling for the `ChangeError`.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
