### PR TITLE
chore: Move to codespell and ruff 

### DIFF
--- a/lib/charms/sdcore_upf_k8s/v0/fiveg_n3.py
+++ b/lib/charms/sdcore_upf_k8s/v0/fiveg_n3.py
@@ -93,7 +93,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 
@@ -129,7 +129,7 @@ class ProviderSchema(DataBagSchema):
 
 
 def data_matches_provider_schema(data: dict) -> bool:
-    """Returns whether data matches provider schema.
+    """Return whether data matches provider schema.
 
     Args:
         data (dict): Data to be validated.
@@ -149,18 +149,18 @@ class FiveGN3RequestEvent(EventBase):
     """Dataclass for the `fiveg_n3` request event."""
 
     def __init__(self, handle, relation_id: int):
-        """Sets relation id."""
+        """Set relation id."""
         super().__init__(handle)
         self.relation_id = relation_id
 
     def snapshot(self) -> dict:
-        """Returns event data."""
+        """Return event data."""
         return {
             "relation_id": self.relation_id,
         }
 
     def restore(self, snapshot):
-        """Restores event data."""
+        """Restore event data."""
         self.relation_id = snapshot["relation_id"]
 
 
@@ -176,7 +176,7 @@ class N3Provides(Object):
     on = N3ProviderCharmEvents()
 
     def __init__(self, charm: CharmBase, relation_name: str):
-        """Observes relation joined event.
+        """Observe relation joined event.
 
         Args:
             charm: Juju charm
@@ -188,7 +188,7 @@ class N3Provides(Object):
         self.framework.observe(charm.on[relation_name].relation_joined, self._on_relation_joined)
 
     def publish_upf_information(self, relation_id: int, upf_ip_address: str) -> None:
-        """Sets UPF's IP address in the relation data.
+        """Set UPF's IP address in the relation data.
 
         Args:
             relation_id (str): Relation ID
@@ -216,16 +216,16 @@ class N3AvailableEvent(EventBase):
     """Dataclass for the `fiveg_n3` available event."""
 
     def __init__(self, handle, upf_ip_address: str):
-        """Sets certificate."""
+        """Set certificate."""
         super().__init__(handle)
         self.upf_ip_address = upf_ip_address
 
     def snapshot(self) -> dict:
-        """Returns event data."""
+        """Return event data."""
         return {"upf_ip_address": self.upf_ip_address}
 
     def restore(self, snapshot):
-        """Restores event data."""
+        """Restore event data."""
         self.upf_ip_address = snapshot["upf_ip_address"]
 
 
@@ -241,7 +241,7 @@ class N3Requires(Object):
     on = N3RequirerCharmEvents()
 
     def __init__(self, charm: CharmBase, relation_name: str):
-        """Observes relation joined and relation changed events.
+        """Observe relation joined and relation changed events.
 
         Args:
             charm: Juju charm

--- a/lib/charms/sdcore_upf_k8s/v0/fiveg_n3.py
+++ b/lib/charms/sdcore_upf_k8s/v0/fiveg_n3.py
@@ -254,7 +254,7 @@ class N3Requires(Object):
         self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Triggered everytime there's a change in relation data.
+        """Triggered every time there's a change in relation data.
 
         Args:
             event (RelationChangedEvent): Juju event

--- a/lib/charms/sdcore_upf_k8s/v0/fiveg_n4.py
+++ b/lib/charms/sdcore_upf_k8s/v0/fiveg_n4.py
@@ -98,7 +98,7 @@ LIBAPI = 0
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 1
+LIBPATCH = 2
 
 PYDEPS = ["pydantic", "pytest-interface-tester"]
 
@@ -142,7 +142,7 @@ class ProviderSchema(DataBagSchema):
 
 
 def data_matches_provider_schema(data: dict) -> bool:
-    """Returns whether data matches provider schema.
+    """Return whether data matches provider schema.
 
     Args:
         data (dict): Data to be validated.
@@ -162,18 +162,18 @@ class FiveGN4RequestEvent(EventBase):
     """Dataclass for the `fiveg_n4` request event."""
 
     def __init__(self, handle, relation_id: int):
-        """Sets relation id."""
+        """Set relation id."""
         super().__init__(handle)
         self.relation_id = relation_id
 
     def snapshot(self) -> dict:
-        """Returns event data."""
+        """Return event data."""
         return {
             "relation_id": self.relation_id,
         }
 
     def restore(self, snapshot):
-        """Restores event data."""
+        """Restore event data."""
         self.relation_id = snapshot["relation_id"]
 
 
@@ -189,7 +189,7 @@ class N4Provides(Object):
     on = N4ProviderCharmEvents()
 
     def __init__(self, charm: CharmBase, relation_name: str):
-        """Observes relation joined event.
+        """Observe relation joined event.
 
         Args:
             charm: Juju charm
@@ -203,7 +203,7 @@ class N4Provides(Object):
     def publish_upf_n4_information(
         self, relation_id: int, upf_hostname: str, upf_n4_port: int
     ) -> None:
-        """Sets UPF's hostname and port in the relation data.
+        """Set UPF's hostname and port in the relation data.
 
         Args:
             relation_id (str): Relation ID
@@ -235,13 +235,13 @@ class N4AvailableEvent(EventBase):
     """Dataclass for the `fiveg_n4` available event."""
 
     def __init__(self, handle, upf_hostname: str, upf_port: int):
-        """Sets UPF's hostname and port."""
+        """Set UPF's hostname and port."""
         super().__init__(handle)
         self.upf_hostname = upf_hostname
         self.upf_port = upf_port
 
     def snapshot(self) -> dict:
-        """Returns event data."""
+        """Return event data."""
         return {
             "upf_hostname": self.upf_hostname,
             "upf_port": self.upf_port,
@@ -265,7 +265,7 @@ class N4Requires(Object):
     on = N4RequirerCharmEvents()
 
     def __init__(self, charm: CharmBase, relation_name: str):
-        """Observes relation joined and relation changed events.
+        """Observe relation joined and relation changed events.
 
         Args:
             charm: Juju charm

--- a/lib/charms/sdcore_upf_k8s/v0/fiveg_n4.py
+++ b/lib/charms/sdcore_upf_k8s/v0/fiveg_n4.py
@@ -278,7 +278,7 @@ class N4Requires(Object):
         self.framework.observe(charm.on[relation_name].relation_changed, self._on_relation_changed)
 
     def _on_relation_changed(self, event: RelationChangedEvent) -> None:
-        """Triggered everytime there's a change in relation data.
+        """Triggered every time there's a change in relation data.
 
         Args:
             event (RelationChangedEvent): Juju event

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ extend-ignore = [
     "D204",
     "D213",
     "D215",
+    "D107",
     "D400",
     "D404",
     "D406",
@@ -27,7 +28,6 @@ extend-ignore = [
     "D409",
     "D413",
 ]
-ignore = ["E501", "D107"]
 per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
 [tool.ruff.lint.mccabe]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,24 +9,29 @@ show_missing = true
 minversion = "6.0"
 log_cli_level = "INFO"
 
-# Formatting tools configuration
-[tool.black]
+[tool.ruff]
 line-length = 99
-target-version = ["py38"]
 
-[tool.isort]
-line_length = 99
-profile = "black"
+[tool.ruff.lint]
+select = ["E", "W", "F", "C", "N", "D", "I001"]
+extend-ignore = [
+    "D203",
+    "D204",
+    "D213",
+    "D215",
+    "D400",
+    "D404",
+    "D406",
+    "D407",
+    "D408",
+    "D409",
+    "D413",
+]
+ignore = ["E501", "D107"]
+per-file-ignores = {"tests/*" = ["D100","D101","D102","D103","D104"]}
 
-# Linting tools configuration
-[tool.flake8]
-max-line-length = 99
-max-doc-length = 99
+[tool.ruff.lint.mccabe]
 max-complexity = 10
-exclude = [".git", "__pycache__", ".tox", "build", "dist", "*.egg_info", "venv"]
-select = ["E", "W", "F", "C", "N", "R", "D", "H"]
-# Ignore D107 Missing docstring in __init__
-ignore = ["D107"]
-# D100, D101, D102, D103: Ignore missing docstrings in tests
-per-file-ignores = ["tests/*:D100,D101,D102,D103,D104"]
-docstring-convention = "google"
+
+[tool.codespell]
+skip = "build,lib,venv,icon.svg,.tox,.git,.mypy_cache,.ruff_cache,.coverage"

--- a/src/charm.py
+++ b/src/charm.py
@@ -424,7 +424,9 @@ class UPFOperatorCharm(CharmBase):
 
     @staticmethod
     def _get_nad_base_config() -> Dict[Any, Any]:
-        """Get the base NetworkAttachmentDefinition config to be extended according to charm config.
+        """Get the base NetworkAttachmentDefinition.
+
+        This config is extended according to charm config.
 
         Returns:
             config (dict): Base NAD config

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -58,7 +58,7 @@ class CharmConfigInvalidError(Exception):
 
 
 def to_kebab(name: str) -> str:
-    """Converts a snake_case string to kebab-case."""
+    """Convert a snake_case string to kebab-case."""
     return name.replace("_", "-")
 
 

--- a/src/dpdk.py
+++ b/src/dpdk.py
@@ -48,7 +48,7 @@ class DPDK:
         }
 
     def is_configured(self, container_name: str) -> bool:
-        """Checks whether the container config required for DPDK has been applied or not.
+        """Check whether the container config required for DPDK has been applied or not.
 
         Args:
             container_name (str): Name of the container to update
@@ -72,7 +72,7 @@ class DPDK:
         return True
 
     def configure(self, container_name: str) -> None:
-        """Applies config required by DPDK to a given container.
+        """Apply config required by DPDK to a given container.
 
         Args:
             container_name (str): Name of the container to update
@@ -96,7 +96,7 @@ class DPDK:
         logger.info("Container %s configured for DPDK", container_name)
 
     def _get_statefulset(self, statefulset_name: str, namespace: str) -> Optional[StatefulSet]:
-        """Returns StatefulSet object with given name from given namespace.
+        """Return StatefulSet object with given name from given namespace.
 
         Args:
             statefulset_name (str): Name of the StatefulSet to get
@@ -114,7 +114,7 @@ class DPDK:
     def _get_container(
         containers: Iterable[Container], container_name: str
     ) -> Optional[Container]:
-        """Returns Container object with given name.
+        """Return Container object with given name.
 
         Args:
             containers (Iterable[Container]): Containers to search among
@@ -130,7 +130,7 @@ class DPDK:
 
     @staticmethod
     def _apply_resource_requirements(container: Container, resource_requirements: dict) -> None:
-        """Applies given resource requests and limits to a given container.
+        """Apply given resource requests and limits to a given container.
 
         Args:
             container (Container): Container to update
@@ -148,7 +148,7 @@ class DPDK:
 
     @staticmethod
     def _resource_requirements_applied(container: Container, resource_requirements: dict) -> bool:
-        """Checks whether the container ResourceRequirements have been applied or not.
+        """Check whether the container ResourceRequirements have been applied or not.
 
         Args:
             container (Container): Container to check
@@ -166,7 +166,7 @@ class DPDK:
         return True
 
     def _replace_statefulset(self, statefulset: StatefulSet) -> None:
-        """Replaces StatefulSet.
+        """Replace StatefulSet.
 
         Args:
             statefulset (StatefulSet): StatefulSet object to replace

--- a/test-requirements.in
+++ b/test-requirements.in
@@ -1,18 +1,14 @@
-black
+codespell
 coverage[toml]
-flake8-docstrings
-flake8-builtins
-isort
 juju
 macaroonbakery==1.3.4  # https://protobuf.dev/news/2022-05-06/#python-updates
 mypy
-pep8-naming
-pyproject-flake8
 pytest
 pytest-asyncio==0.21.1
 pytest-interface-tester
 pydantic==2.6.4
 pytest-operator
+ruff
 types-PyYAML
 types-setuptools
 types-toml

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -10,8 +10,6 @@ asttokens==2.4.1
     # via stack-data
 bcrypt==4.1.2
     # via paramiko
-black==24.3.0
-    # via -r test-requirements.in
 cachetools==5.3.2
     # via google-auth
 certifi==2024.2.2
@@ -20,34 +18,25 @@ certifi==2024.2.2
     #   requests
 cffi==1.16.0
     # via
+    #   -c requirements.txt
     #   cryptography
     #   pynacl
 charset-normalizer==3.3.2
     # via requests
-click==8.1.7
-    # via
-    #   black
-    #   typer
+codespell==2.2.6
+    # via -r test-requirements.in
 coverage[toml]==7.4.4
     # via -r test-requirements.in
 cryptography==42.0.5
-    # via paramiko
+    # via
+    #   -c requirements.txt
+    #   paramiko
 decorator==5.1.1
     # via
     #   ipdb
     #   ipython
 executing==2.0.1
     # via stack-data
-flake8==7.0.0
-    # via
-    #   flake8-builtins
-    #   flake8-docstrings
-    #   pep8-naming
-    #   pyproject-flake8
-flake8-builtins==2.5.0
-    # via -r test-requirements.in
-flake8-docstrings==1.7.0
-    # via -r test-requirements.in
 google-auth==2.28.1
     # via kubernetes
 hvac==2.1.0
@@ -55,17 +44,19 @@ hvac==2.1.0
 idna==3.6
     # via requests
 iniconfig==2.0.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 ipdb==0.13.13
     # via pytest-operator
 ipython==8.22.1
     # via ipdb
-isort==5.13.2
-    # via -r test-requirements.in
 jedi==0.19.1
     # via ipython
 jinja2==3.1.3
-    # via pytest-operator
+    # via
+    #   -c requirements.txt
+    #   pytest-operator
 juju==3.4.0.0
     # via
     #   -r test-requirements.in
@@ -77,16 +68,15 @@ macaroonbakery==1.3.4
     #   -r test-requirements.in
     #   juju
 markupsafe==2.1.5
-    # via jinja2
+    # via
+    #   -c requirements.txt
+    #   jinja2
 matplotlib-inline==0.1.6
     # via ipython
-mccabe==0.7.0
-    # via flake8
 mypy==1.9.0
     # via -r test-requirements.in
 mypy-extensions==1.0.0
     # via
-    #   black
     #   mypy
     #   typing-inspect
 oauthlib==3.2.2
@@ -99,23 +89,19 @@ ops-scenario==6.0.1
     # via pytest-interface-tester
 packaging==23.2
     # via
-    #   black
+    #   -c requirements.txt
     #   juju
     #   pytest
 paramiko==3.4.0
     # via juju
 parso==0.8.3
     # via jedi
-pathspec==0.12.1
-    # via black
-pep8-naming==0.13.3
-    # via -r test-requirements.in
 pexpect==4.9.0
     # via ipython
-platformdirs==4.2.0
-    # via black
 pluggy==1.4.0
-    # via pytest
+    # via
+    #   -c requirements.txt
+    #   pytest
 prompt-toolkit==3.0.43
     # via ipython
 protobuf==4.25.3
@@ -131,20 +117,16 @@ pyasn1==0.5.1
     #   rsa
 pyasn1-modules==0.3.0
     # via google-auth
-pycodestyle==2.11.1
-    # via flake8
 pycparser==2.21
-    # via cffi
+    # via
+    #   -c requirements.txt
+    #   cffi
 pydantic==2.6.4
     # via
     #   -r test-requirements.in
     #   pytest-interface-tester
 pydantic-core==2.16.3
     # via pydantic
-pydocstyle==6.3.0
-    # via flake8-docstrings
-pyflakes==3.2.0
-    # via flake8
 pygments==2.17.2
     # via ipython
 pymacaroons==0.13.0
@@ -154,14 +136,13 @@ pynacl==1.5.0
     #   macaroonbakery
     #   paramiko
     #   pymacaroons
-pyproject-flake8==7.0.0
-    # via -r test-requirements.in
 pyrfc3339==1.1
     # via
     #   juju
     #   macaroonbakery
 pytest==8.1.1
     # via
+    #   -c requirements.txt
     #   -r test-requirements.in
     #   pytest-asyncio
     #   pytest-interface-tester
@@ -180,6 +161,7 @@ pytz==2024.1
     # via pyrfc3339
 pyyaml==6.0.1
     # via
+    #   -c requirements.txt
     #   juju
     #   kubernetes
     #   ops
@@ -195,6 +177,8 @@ requests-oauthlib==1.3.1
     # via kubernetes
 rsa==4.9
     # via google-auth
+ruff==0.3.5
+    # via -r test-requirements.in
 six==1.16.0
     # via
     #   asttokens
@@ -202,8 +186,6 @@ six==1.16.0
     #   macaroonbakery
     #   pymacaroons
     #   python-dateutil
-snowballstemmer==2.2.0
-    # via pydocstyle
 stack-data==0.6.3
     # via ipython
 toposort==1.10
@@ -222,6 +204,7 @@ types-toml==0.10.8.20240310
     # via -r test-requirements.in
 typing-extensions==4.10.0
     # via
+    #   -c requirements.txt
     #   mypy
     #   pydantic
     #   pydantic-core
@@ -236,6 +219,7 @@ wcwidth==0.2.13
     # via prompt-toolkit
 websocket-client==1.7.0
     # via
+    #   -c requirements.txt
     #   kubernetes
     #   ops
 websockets==12.0

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_provider_charm/src/charm.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_provider_charm/src/charm.py
@@ -17,7 +17,7 @@ class WhateverCharm(CharmBase):
     TEST_UPF_PORT = 0
 
     def __init__(self, *args):
-        """Creates a new instance of this object for each event."""
+        """Create a new instance of this object for each event."""
         super().__init__(*args)
         self.fiveg_n3_provider = N3Provides(self, "fiveg_n3")
         self.fiveg_n4_provider = N4Provides(self, "fiveg_n4")

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_requirer_charm/src/charm.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_charms/test_requirer_charm/src/charm.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 class WhateverCharm(CharmBase):
     def __init__(self, *args):
-        """Creates a new instance of this object for each event."""
+        """Create a new instance of this object for each event."""
         super().__init__(*args)
         self.fiveg_n3 = N3Requires(self, "fiveg_n3")
         self.fiveg_n4 = N4Requires(self, "fiveg_n4")

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -5,6 +5,15 @@ import json
 import unittest
 from unittest.mock import Mock, call, patch
 
+from charm import (
+    ACCESS_INTERFACE_NAME,
+    ACCESS_NETWORK_ATTACHMENT_DEFINITION_NAME,
+    CORE_INTERFACE_NAME,
+    CORE_NETWORK_ATTACHMENT_DEFINITION_NAME,
+    DPDK_ACCESS_INTERFACE_RESOURCE_NAME,
+    DPDK_CORE_INTERFACE_RESOURCE_NAME,
+    UPFOperatorCharm,
+)
 from charms.kubernetes_charm_libraries.v0.multus import (  # type: ignore[import]
     NetworkAnnotation,
     NetworkAttachmentDefinition,
@@ -15,16 +24,6 @@ from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Service
 from ops import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus, testing
 from ops.pebble import ConnectionError
-
-from charm import (
-    ACCESS_INTERFACE_NAME,
-    ACCESS_NETWORK_ATTACHMENT_DEFINITION_NAME,
-    CORE_INTERFACE_NAME,
-    CORE_NETWORK_ATTACHMENT_DEFINITION_NAME,
-    DPDK_ACCESS_INTERFACE_RESOURCE_NAME,
-    DPDK_CORE_INTERFACE_RESOURCE_NAME,
-    UPFOperatorCharm,
-)
 
 MULTUS_LIBRARY_PATH = "charms.kubernetes_charm_libraries.v0.multus"
 HUGEPAGES_LIBRARY_PATH = "charms.kubernetes_charm_libraries.v0.hugepages_volumes_patch"
@@ -48,7 +47,7 @@ INVALID_CORE_MAC = "wrong"
 
 
 def read_file(path: str) -> str:
-    """Reads a file and returns as a string.
+    """Read a file and returns as a string.
 
     Args:
         path (str): path to the file.
@@ -62,7 +61,7 @@ def read_file(path: str) -> str:
 
 
 def update_nad_labels(nads: list[NetworkAttachmentDefinition], app_name: str) -> None:
-    """Sets NetworkAttachmentDefinition metadata labels.
+    """Set NetworkAttachmentDefinition metadata labels.
 
     Args:
         nads: list of NetworkAttachmentDefinition

--- a/tests/unit/test_dpdk.py
+++ b/tests/unit/test_dpdk.py
@@ -4,6 +4,7 @@
 import unittest
 from unittest.mock import MagicMock, Mock, patch
 
+from dpdk import DPDK, DPDKError
 from lightkube.core.exceptions import ApiError
 from lightkube.models.apps_v1 import StatefulSetSpec
 from lightkube.models.core_v1 import (
@@ -15,8 +16,6 @@ from lightkube.models.core_v1 import (
 )
 from lightkube.models.meta_v1 import LabelSelector, ObjectMeta
 from lightkube.resources.apps_v1 import StatefulSet
-
-from dpdk import DPDK, DPDKError
 
 TEST_CONTAINER_NAME = "bullseye"
 TEST_RESOURCE_REQUESTS = {"test_request": 1234}

--- a/tox.ini
+++ b/tox.ini
@@ -34,6 +34,7 @@ commands =
 [testenv:lint]
 description = Check code against coding style standards
 commands =
+    codespell {[vars]lib_path}
     codespell {tox_root}
     ruff check {[vars]all_path}
 

--- a/tox.ini
+++ b/tox.ini
@@ -29,15 +29,13 @@ passenv =
 [testenv:fmt]
 description = Apply coding style standards to code
 commands =
-    isort {[vars]all_path}
-    black --target-version py310 {[vars]all_path}
+    ruff check --fix {[vars]all_path}
 
 [testenv:lint]
 description = Check code against coding style standards
 commands =
-    pflake8 {[vars]all_path}
-    isort --check-only --diff {[vars]all_path}
-    black --target-version py310 --check --diff {[vars]all_path}
+    codespell {tox_root}
+    ruff check {[vars]all_path}
 
 [testenv:static]
 description = Run static analysis checks


### PR DESCRIPTION
# Description

Move to ruff and codespell for linting. `pyproject-flake8` is currently broken on Python 3.12, making development on Noble break.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
