### PR TITLE
fix: handle charm status only from CollectStatus event callback

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -106,8 +106,7 @@ class UPFOperatorCharm(CharmBase):
         self.unit.set_ports(PROMETHEUS_PORT)
         try:
             self._charm_config: CharmConfig = CharmConfig.from_charm(charm=self)
-        except CharmConfigInvalidError as exc:
-            self.model.unit.status = BlockedStatus(exc.msg)
+        except CharmConfigInvalidError:
             return
         self._kubernetes_multus = KubernetesMultusCharmLib(
             charm=self,

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -99,6 +99,7 @@ class TestCharmInitialisation(unittest.TestCase):
         ]
         self.harness.update_config(key_values={"dnn": ""})
         self.harness.begin()
+        self.harness.evaluate_status()
 
         self.assertEqual(
             self.harness.model.unit.status,
@@ -118,6 +119,7 @@ class TestCharmInitialisation(unittest.TestCase):
         ]
         self.harness.update_config(key_values={"upf-mode": ""})
         self.harness.begin()
+        self.harness.evaluate_status()
 
         self.assertEqual(
             self.harness.model.unit.status,
@@ -139,6 +141,7 @@ class TestCharmInitialisation(unittest.TestCase):
         ]
         self.harness.update_config(key_values={"upf-mode": "unsupported"})
         self.harness.begin()
+        self.harness.evaluate_status()
 
         self.assertEqual(
             self.harness.model.unit.status,
@@ -162,6 +165,7 @@ class TestCharmInitialisation(unittest.TestCase):
         ]
         self.harness.update_config(key_values={"cni-type": "vfioveth", "upf-mode": "dpdk"})
         self.harness.begin()
+        self.harness.evaluate_status()
 
         self.assertEqual(
             self.harness.model.unit.status,
@@ -187,6 +191,7 @@ class TestCharmInitialisation(unittest.TestCase):
         ]
         self.harness.update_config(key_values={"cni-type": "vfioveth", "upf-mode": "dpdk"})
         self.harness.begin()
+        self.harness.evaluate_status()
 
         self.assertEqual(
             self.harness.model.unit.status,
@@ -219,6 +224,7 @@ class TestCharmInitialisation(unittest.TestCase):
             }
         )
         self.harness.begin()
+        self.harness.evaluate_status()
 
         self.assertEqual(
             self.harness.model.unit.status,
@@ -251,6 +257,7 @@ class TestCharmInitialisation(unittest.TestCase):
             }
         )
         self.harness.begin()
+        self.harness.evaluate_status()
 
         self.assertEqual(
             self.harness.model.unit.status,
@@ -298,6 +305,8 @@ class TestCharmInitialisation(unittest.TestCase):
             }
         )
         self.harness.begin()
+        self.harness.evaluate_status()
+
         self.assertEqual(
             self.harness.model.unit.status,
             BlockedStatus(


### PR DESCRIPTION
# Description

This PR aims to fix #173. Status setting is removed from the try-except block during `__init__` and it now relies only on the `CollectStatus` event callback.
Unit tests requiring charm reinstatiation, as updated by #147, are updated evaluating the unit status.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
