### PR TITLE
fix: Initializing KubernetesMultusCharmLib with privileged mode

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -115,6 +115,7 @@ class UPFOperatorCharm(CharmBase):
             network_annotations_func=self._generate_network_annotations,
             network_attachment_definitions_func=self._network_attachment_definitions_from_config,
             refresh_event=self.on.nad_config_changed,
+            privileged=self._get_privilege_required(),
         )
         self._kubernetes_volumes_patch = KubernetesHugePagesPatchCharmLib(
             charm=self,
@@ -135,6 +136,9 @@ class UPFOperatorCharm(CharmBase):
         )
         self.framework.observe(self.on.install, self._on_install)
         self.framework.observe(self.on.remove, self._on_remove)
+
+    def _get_privilege_required(self) -> bool:
+        return self._charm_config.upf_mode == UpfMode.dpdk
 
     def _create_external_upf_service(self) -> None:
         client = Client()


### PR DESCRIPTION
# Description

- Fixes https://github.com/canonical/sdcore-upf-k8s-operator/issues/172.
First of all, UPF charm initialize the Multus library without privilege. Then DPDK library patches the statefulset to privileged mode. Upon destroy, Multus library tries to get back the privilege by unpatching. However, statefulset is modified by DPDK library causes the API error reported in https://github.com/canonical/sdcore-upf-k8s-operator/issues/172.  If we initialize Multus library with privileged when the UPF is in DPDK mode, this issue is solved.

Tested by deploying UPF in DPDK mode and confirmed that the UPF is removed successfully without manual intervention.


# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
