### PR TITLE
fix: Fixes charm status when HugePages are not available

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -1824,7 +1824,6 @@ class TestCharm(unittest.TestCase):
         patch_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
-            [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1867,7 +1866,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("CPU is not compatible, see logs for more details"),
+            BlockedStatus("Not enough HugePages available"),
         )
 
     @patch("charm.check_output")
@@ -1905,7 +1904,7 @@ class TestCharm(unittest.TestCase):
 
         self.assertEqual(
             self.harness.model.unit.status,
-            BlockedStatus("CPU is not compatible, see logs for more details"),
+            BlockedStatus("Not enough HugePages available"),
         )
 
         self.harness.charm.on.update_status.emit()


### PR DESCRIPTION
# Description

This PR fixes the invalid charm status displayed in a situation when the operator forgets to create required amount of HugePages. Before this change, the status would say "Incompatible CPU" instead of "Not enough HugePages".

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
