### PR TITLE
fix: Blocks starting routectl if bess is not configured

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -706,9 +706,11 @@ class UPFOperatorCharm(CharmBase):
         This function adds the Pebble layer defining the `routectl` service. The Pebble layer will
         only be added if it doesn't already exist.
         Through the `restart_service` argument, the function also allows to restart
-        the `bessd` service (even if there was no change in the Pebble layer) if it is required
+        the `routectl` service (even if there was no change in the Pebble layer) if it is required
         (e.g. when the UPF configuration file has changed).
         """
+        if not self._is_bessd_configured():
+            return
         plan = self._bessd_container.get_plan()
         if not all(service in plan.services for service in self._routectl_pebble_layer.services):
             self._bessd_container.add_layer("routectl", self._routectl_pebble_layer, combine=True)


### PR DESCRIPTION
# Description

This PR follows up on #220. After last change, `routectl` would still be started even if `bess` was not configured.
This PR fixes that problem by checking whether `bess` is configured before starting `routectl`

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
- [x] I have bumped the version of the library
