### PR TITLE
chore: use pytest

### DIFF
--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_provider.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_provider.py
@@ -1,49 +1,61 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import unittest
+import pytest
 from unittest.mock import PropertyMock, patch
 
 from ops import testing
 from test_charms.test_provider_charm.src.charm import WhateverCharm  # type: ignore[import]
 
+RELATION_NAME = "fiveg_n3"
+REMOVE_APP = "whatever-app"
 TEST_CHARM_PATH = "test_charms.test_provider_charm.src.charm.WhateverCharm"
 
-
-class TestN3Provides(unittest.TestCase):
+class TestN3Provides:
+    
+    patcher_upf_ip_address = patch(f"{TEST_CHARM_PATH}.TEST_UPF_IP_ADDRESS", new_callable=PropertyMock)
+    
+    @pytest.fixture()
     def setUp(self) -> None:
-        self.harness = testing.Harness(WhateverCharm)
-        self.addCleanup(self.harness.cleanup)
-        self.harness.begin()
-        self.relation_name = "fiveg_n3"
+        self.mock_upf_ip_address = TestN3Provides.patcher_upf_ip_address.start()
 
-    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_IP_ADDRESS", new_callable=PropertyMock)
-    def test_given_fiveg_n3_relation_when_relation_created_then_upf_ip_address_is_published_in_the_relation_data(  # noqa: E501
-        self, patched_test_upf_ip
-    ):
+    @staticmethod
+    def tearDown() -> None:
+        patch.stopall()
+        
+    @pytest.fixture(autouse=True)
+    def harness(self, setUp, request):
+        self.harness = testing.Harness(WhateverCharm)
+        self.harness.set_model_name(name="whatever")
         self.harness.set_leader(is_leader=True)
+        self.harness.begin()
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.tearDown)
+
+    def test_given_fiveg_n3_relation_when_relation_created_then_upf_ip_address_is_published_in_the_relation_data(  # noqa: E501
+        self,
+    ):
         test_upf_ip = "1.2.3.4"
-        patched_test_upf_ip.return_value = test_upf_ip
+        self.mock_upf_ip_address.return_value = test_upf_ip
         relation_id = self.harness.add_relation(
-            relation_name=self.relation_name, remote_app="whatever-app"
+            relation_name=RELATION_NAME, remote_app=REMOVE_APP
         )
-        self.harness.add_relation_unit(relation_id, "whatever-app/0")
+        self.harness.add_relation_unit(relation_id, f"{REMOVE_APP}/0")
 
         relation_data = self.harness.get_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.app
         )
-        self.assertEqual(test_upf_ip, relation_data["upf_ip_address"])
+        assert test_upf_ip == relation_data["upf_ip_address"]
 
-    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_IP_ADDRESS", new_callable=PropertyMock)
     def test_given_invalid_upf_ip_address_when_relation_created_then_value_error_is_raised(
-        self, patched_test_upf_ip
+        self,
     ):
-        self.harness.set_leader(is_leader=True)
         invalid_upf_ip = "777.888.9999.0"
-        patched_test_upf_ip.return_value = invalid_upf_ip
+        self.mock_upf_ip_address.return_value = invalid_upf_ip
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             relation_id = self.harness.add_relation(
-                relation_name=self.relation_name, remote_app="whatever-app"
+                relation_name=RELATION_NAME, remote_app=REMOVE_APP
             )
-            self.harness.add_relation_unit(relation_id, "whatever-app/0")
+            self.harness.add_relation_unit(relation_id, f"{REMOVE_APP}/0")

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_provider.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_provider.py
@@ -1,9 +1,9 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import pytest
 from unittest.mock import PropertyMock, patch
 
+import pytest
 from ops import testing
 from test_charms.test_provider_charm.src.charm import WhateverCharm  # type: ignore[import]
 
@@ -12,9 +12,9 @@ REMOVE_APP = "whatever-app"
 TEST_CHARM_PATH = "test_charms.test_provider_charm.src.charm.WhateverCharm"
 
 class TestN3Provides:
-    
-    patcher_upf_ip_address = patch(f"{TEST_CHARM_PATH}.TEST_UPF_IP_ADDRESS", new_callable=PropertyMock)
-    
+
+    patcher_upf_ip_address = patch(f"{TEST_CHARM_PATH}.TEST_UPF_IP_ADDRESS", new_callable=PropertyMock)   # noqa E501
+
     @pytest.fixture()
     def setUp(self) -> None:
         self.mock_upf_ip_address = TestN3Provides.patcher_upf_ip_address.start()
@@ -22,7 +22,7 @@ class TestN3Provides:
     @staticmethod
     def tearDown() -> None:
         patch.stopall()
-        
+
     @pytest.fixture(autouse=True)
     def harness(self, setUp, request):
         self.harness = testing.Harness(WhateverCharm)

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_requirer.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_requirer.py
@@ -1,27 +1,40 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import unittest
+import pytest
 from unittest.mock import call, patch
 
 from ops import testing
 from test_charms.test_requirer_charm.src.charm import WhateverCharm  # type: ignore[import]
 
 
-class TestN3Requires(unittest.TestCase):
+class TestN3Requires:
+    
+    patcher_n3_available = patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3RequirerCharmEvents.fiveg_n3_available")
+    
+    @pytest.fixture()
     def setUp(self) -> None:
+        self.mock_n3_available = TestN3Requires.patcher_n3_available.start()
+        
+    @staticmethod
+    def tearDown() -> None:
+        patch.stopall()
+        
+    @pytest.fixture(autouse=True)
+    def harness(self, setUp, request):
         self.harness = testing.Harness(WhateverCharm)
-        self.addCleanup(self.harness.cleanup)
+        self.harness.set_model_name(name="whatever")
         self.harness.begin()
-        self.relation_name = "fiveg_n3"
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.tearDown)
 
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3RequirerCharmEvents.fiveg_n3_available")
     def test_given_relation_with_n3_provider_when_fiveg_n3_available_event_then_n3_information_is_provided(  # noqa: E501
-        self, patched_fiveg_n3_available_event
+        self, 
     ):
         test_upf_ip = "1.2.3.4"
         relation_id = self.harness.add_relation(
-            relation_name=self.relation_name, remote_app="whatever-app"
+            relation_name="fiveg_n3", remote_app="whatever-app"
         )
         self.harness.add_relation_unit(relation_id, "whatever-app/0")
 
@@ -34,4 +47,4 @@ class TestN3Requires(unittest.TestCase):
         calls = [
             call.emit(upf_ip_address=test_upf_ip),
         ]
-        patched_fiveg_n3_available_event.assert_has_calls(calls)
+        self.mock_n3_available.assert_has_calls(calls)

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_requirer.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n3_requirer.py
@@ -1,25 +1,26 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import pytest
 from unittest.mock import call, patch
 
-from ops import testing
+import pytest
+from ops import BoundEvent, testing
 from test_charms.test_requirer_charm.src.charm import WhateverCharm  # type: ignore[import]
 
 
 class TestN3Requires:
-    
-    patcher_n3_available = patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3RequirerCharmEvents.fiveg_n3_available")
-    
+
+    patcher_n3_available = patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3RequirerCharmEvents.fiveg_n3_available")   # noqa E501
+
     @pytest.fixture()
     def setUp(self) -> None:
         self.mock_n3_available = TestN3Requires.patcher_n3_available.start()
-        
+        self.mock_n3_available.__class__ = BoundEvent
+
     @staticmethod
     def tearDown() -> None:
         patch.stopall()
-        
+
     @pytest.fixture(autouse=True)
     def harness(self, setUp, request):
         self.harness = testing.Harness(WhateverCharm)
@@ -30,7 +31,7 @@ class TestN3Requires:
         request.addfinalizer(self.tearDown)
 
     def test_given_relation_with_n3_provider_when_fiveg_n3_available_event_then_n3_information_is_provided(  # noqa: E501
-        self, 
+        self,
     ):
         test_upf_ip = "1.2.3.4"
         relation_id = self.harness.add_relation(

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_provider.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_provider.py
@@ -1,73 +1,71 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import unittest
+import pytest
 from unittest.mock import PropertyMock, patch
 
 from ops import testing
 from test_charms.test_provider_charm.src.charm import WhateverCharm  # type: ignore[import]
 
 TEST_CHARM_PATH = "test_charms.test_provider_charm.src.charm.WhateverCharm"
+VALID_HOSTNAME = "upf.edge-cloud.test.com"
+VALID_PORT = 1234
 
-
-class TestN4Provides(unittest.TestCase):
+class TestN4Provides:
+    
+    patcher_upf_hostname = patch(f"{TEST_CHARM_PATH}.TEST_UPF_HOSTNAME", new_callable=PropertyMock)
+    patcher_upf_port = patch(f"{TEST_CHARM_PATH}.TEST_UPF_PORT", new_callable=PropertyMock)
+    
+    @pytest.fixture()
     def setUp(self) -> None:
+        self.mock_upf_hostname = TestN4Provides.patcher_upf_hostname.start()
+        self.mock_upf_port = TestN4Provides.patcher_upf_port.start()
+        self.mock_upf_hostname.return_value = VALID_HOSTNAME
+        self.mock_upf_port.return_value = VALID_PORT
+    
+    @staticmethod
+    def tearDown() -> None:
+        patch.stopall()
+        
+    @pytest.fixture(autouse=True)
+    def harness(self, setUp, request):
         self.harness = testing.Harness(WhateverCharm)
-        self.addCleanup(self.harness.cleanup)
-        self.harness.begin()
-        self.relation_name = "fiveg_n4"
-
-    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_HOSTNAME", new_callable=PropertyMock)
-    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_PORT", new_callable=PropertyMock)
-    def test_given_fiveg_n4_relation_when_relation_created_then_upf_hostname_and_upf_port_is_published_in_the_relation_data(  # noqa: E501
-        self, patched_test_upf_port, patched_test_upf_hostname
-    ):
+        self.harness.set_model_name(name="whatever")
         self.harness.set_leader(is_leader=True)
-        test_upf_hostname = "upf.edge-cloud.test.com"
-        test_upf_port = 1234
-        patched_test_upf_hostname.return_value = test_upf_hostname
-        patched_test_upf_port.return_value = test_upf_port
+        self.harness.begin()
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.tearDown)
+        
+    def add_fiveg_n4_relation(self) -> int:
         relation_id = self.harness.add_relation(
-            relation_name=self.relation_name, remote_app="whatever-app"
+            relation_name="fiveg_n4", remote_app="whatever-app"
         )
         self.harness.add_relation_unit(relation_id, "whatever-app/0")
+        return relation_id
 
+    def test_given_fiveg_n4_relation_when_relation_created_then_upf_hostname_and_upf_port_is_published_in_the_relation_data(  # noqa: E501
+        self,
+    ):
+        relation_id = self.add_fiveg_n4_relation()
         relation_data = self.harness.get_relation_data(
             relation_id=relation_id, app_or_unit=self.harness.charm.app
         )
-        self.assertEqual(test_upf_hostname, relation_data["upf_hostname"])
-        self.assertEqual(str(test_upf_port), relation_data["upf_port"])
+        assert VALID_HOSTNAME == relation_data["upf_hostname"]
+        assert str(VALID_PORT) == relation_data["upf_port"]
 
-    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_HOSTNAME", new_callable=PropertyMock)
-    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_PORT", new_callable=PropertyMock)
     def test_given_invalid_upf_hostname_when_relation_created_then_value_error_is_raised(
-        self, patched_test_upf_port, patched_test_upf_hostname
+        self,
     ):
-        self.harness.set_leader(is_leader=True)
         test_invalid_upf_hostname = None
-        test_upf_port = 1234
-        patched_test_upf_hostname.return_value = test_invalid_upf_hostname
-        patched_test_upf_port.return_value = test_upf_port
+        self.mock_upf_hostname.return_value = test_invalid_upf_hostname
+        with pytest.raises(ValueError):
+            self.add_fiveg_n4_relation()
 
-        with self.assertRaises(ValueError):
-            relation_id = self.harness.add_relation(
-                relation_name=self.relation_name, remote_app="whatever-app"
-            )
-            self.harness.add_relation_unit(relation_id, "whatever-app/0")
-
-    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_HOSTNAME", new_callable=PropertyMock)
-    @patch(f"{TEST_CHARM_PATH}.TEST_UPF_PORT", new_callable=PropertyMock)
     def test_given_invalid_upf_port_when_relation_created_then_value_error_is_raised(
-        self, patched_test_upf_port, patched_test_upf_hostname
+        self,
     ):
-        self.harness.set_leader(is_leader=True)
-        test_upf_hostname = "upf.edge-cloud.test.com"
         test_invalid_upf_port = "not_an_int"
-        patched_test_upf_hostname.return_value = test_upf_hostname
-        patched_test_upf_port.return_value = test_invalid_upf_port
-
-        with self.assertRaises(ValueError):
-            relation_id = self.harness.add_relation(
-                relation_name=self.relation_name, remote_app="whatever-app"
-            )
-            self.harness.add_relation_unit(relation_id, "whatever-app/0")
+        self.mock_upf_port.return_value = test_invalid_upf_port
+        with pytest.raises(ValueError):
+            self.add_fiveg_n4_relation()

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_provider.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_provider.py
@@ -1,9 +1,9 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import pytest
 from unittest.mock import PropertyMock, patch
 
+import pytest
 from ops import testing
 from test_charms.test_provider_charm.src.charm import WhateverCharm  # type: ignore[import]
 
@@ -12,21 +12,21 @@ VALID_HOSTNAME = "upf.edge-cloud.test.com"
 VALID_PORT = 1234
 
 class TestN4Provides:
-    
+
     patcher_upf_hostname = patch(f"{TEST_CHARM_PATH}.TEST_UPF_HOSTNAME", new_callable=PropertyMock)
     patcher_upf_port = patch(f"{TEST_CHARM_PATH}.TEST_UPF_PORT", new_callable=PropertyMock)
-    
+
     @pytest.fixture()
     def setUp(self) -> None:
         self.mock_upf_hostname = TestN4Provides.patcher_upf_hostname.start()
         self.mock_upf_port = TestN4Provides.patcher_upf_port.start()
         self.mock_upf_hostname.return_value = VALID_HOSTNAME
         self.mock_upf_port.return_value = VALID_PORT
-    
+
     @staticmethod
     def tearDown() -> None:
         patch.stopall()
-        
+
     @pytest.fixture(autouse=True)
     def harness(self, setUp, request):
         self.harness = testing.Harness(WhateverCharm)
@@ -36,7 +36,7 @@ class TestN4Provides:
         yield self.harness
         self.harness.cleanup()
         request.addfinalizer(self.tearDown)
-        
+
     def add_fiveg_n4_relation(self) -> int:
         relation_id = self.harness.add_relation(
             relation_name="fiveg_n4", remote_app="whatever-app"

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_requirer.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_requirer.py
@@ -1,31 +1,43 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import unittest
+import pytest
 from unittest.mock import call, patch
 
 from ops import testing
 from test_charms.test_requirer_charm.src.charm import WhateverCharm  # type: ignore[import]
 
 
-class TestN4Requires(unittest.TestCase):
+class TestN4Requires:
+    
+    patch_n4_available = patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4RequirerCharmEvents.fiveg_n4_available")
+    
+    @pytest.fixture()
     def setUp(self) -> None:
+        self.mock_n4_available = TestN4Requires.patch_n4_available.start()
+        
+    @staticmethod
+    def tearDown() -> None:
+        patch.stopall()
+        
+    @pytest.fixture(autouse=True)
+    def harness(self, setUp, request):
         self.harness = testing.Harness(WhateverCharm)
-        self.addCleanup(self.harness.cleanup)
+        self.harness.set_model_name(name="whatever")
         self.harness.begin()
-        self.relation_name = "fiveg_n4"
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.tearDown)
 
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4RequirerCharmEvents.fiveg_n4_available")
     def test_given_relation_with_n4_provider_when_fiveg_n4_available_event_then_n4_information_is_provided(  # noqa: E501
-        self, patched_fiveg_n4_available_event
+        self,
     ):
         test_upf_hostname = "upf.edge-cloud.test.com"
         test_upf_port = 1234
         relation_id = self.harness.add_relation(
-            relation_name=self.relation_name, remote_app="whatever-app"
+            relation_name="fiveg_n4", remote_app="whatever-app"
         )
         self.harness.add_relation_unit(relation_id, "whatever-app/0")
-
         self.harness.update_relation_data(
             relation_id=relation_id,
             app_or_unit="whatever-app",
@@ -35,4 +47,4 @@ class TestN4Requires(unittest.TestCase):
         calls = [
             call.emit(upf_hostname=test_upf_hostname, upf_port=str(test_upf_port)),
         ]
-        patched_fiveg_n4_available_event.assert_has_calls(calls)
+        self.mock_n4_available.assert_has_calls(calls)

--- a/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_requirer.py
+++ b/tests/unit/lib/charms/sdcore_upf/v0/test_fiveg_n4_requirer.py
@@ -1,25 +1,26 @@
 # Copyright 2023 Canonical Ltd.
 # See LICENSE file for licensing details.
 
-import pytest
 from unittest.mock import call, patch
 
-from ops import testing
+import pytest
+from ops import BoundEvent, testing
 from test_charms.test_requirer_charm.src.charm import WhateverCharm  # type: ignore[import]
 
 
 class TestN4Requires:
-    
-    patch_n4_available = patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4RequirerCharmEvents.fiveg_n4_available")
-    
+
+    patch_n4_available = patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4RequirerCharmEvents.fiveg_n4_available")   # noqa E501
+
     @pytest.fixture()
     def setUp(self) -> None:
         self.mock_n4_available = TestN4Requires.patch_n4_available.start()
-        
+        self.mock_n4_available.__class__ = BoundEvent
+
     @staticmethod
     def tearDown() -> None:
         patch.stopall()
-        
+
     @pytest.fixture(autouse=True)
     def harness(self, setUp, request):
         self.harness = testing.Harness(WhateverCharm)


### PR DESCRIPTION
# Description

PART 1: this PR only includes `tests/unit/lib` files

Remove `unittest` and use only `pytest` framework to run the unit tests.

Actions on this PR:

Add a `@pytest.fixture` for harness
Add a `@pytest.fixture` to setup patches and mocks
Continue using `Mock`, `call` and `patch` from the `unittest.Mock` library
Use `assert` instead of `self.assert...` methods

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
