### PR TITLE
chore: use pytest

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,9 +2,10 @@
 # See LICENSE file for licensing details.
 
 import json
-import pytest
+import unittest
 from unittest.mock import Mock, call, patch
 
+import pytest
 from charm import (
     ACCESS_INTERFACE_NAME,
     ACCESS_NETWORK_ATTACHMENT_DEFINITION_NAME,
@@ -56,119 +57,81 @@ def read_file(path: str) -> str:
 
 
 def update_nad_labels(nads: list[NetworkAttachmentDefinition], app_name: str) -> None:
-    """Set NetworkAttachmentDefinition metadata labels.
-
-    Args:
-        nads: list of NetworkAttachmentDefinition
-        app_name: application name
-    """
+    """Set NetworkAttachmentDefinition metadata labels."""
     for nad in nads:
         nad.metadata.labels = {"app.juju.is/created-by": app_name}
 
 
 class TestCharmInitialisation:
-    
+
     patcher_k8s_client = patch("lightkube.core.client.GenericSyncClient")
-    patcher_client_list = patch("lightkube.core.client.Client.list")
     patcher_check_output = patch("charm.check_output")
+    patcher_client_list = patch("lightkube.core.client.Client.list")
     patcher_delete_pod = patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.delete_pod")
-    patcher_is_patched = patch(
+    patcher_huge_pages_is_patched = patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
+    )
+    patcher_list_na_definitions = patch(
+        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions"
     )
     patcher_multus_is_ready = patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    patcher_list_na_definitions = patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
-    patcher_get_service = patch("ops.model.Container.get_service")
-    
+
     @pytest.fixture()
     def setUp(self):
         TestCharmInitialisation.patcher_k8s_client.start()
         self.mock_client_list = TestCharmInitialisation.patcher_client_list.start()
-        self.mock_is_patched = TestCharmInitialisation.patcher_is_patched.start()
-        self.mock_check_output = TestCharmInitialisation.patcher_check_output.start()
+        self.mock_cpu_info = TestCharmInitialisation.patcher_check_output.start()
         self.mock_delete_pod = TestCharmInitialisation.patcher_delete_pod.start()
-        self.mock_multus_is_ready = TestCharmInitialisation.patcher_multus_is_ready.start()
+        self.mock_huge_pages_is_enabled = TestCharmInitialisation.patcher_huge_pages_is_patched.start()  # noqa E501
         self.mock_list_na_definitions = TestCharmInitialisation.patcher_list_na_definitions.start()
-        self.mock_get_service = TestCharmInitialisation.patcher_get_service.start()
-        
+        self.mock_multus_is_ready = TestCharmInitialisation.patcher_multus_is_ready.start()
+
     @staticmethod
     def tearDown() -> None:
         patch.stopall()
-        
-    def add_storage(self) -> None:
-        self.root = self.harness.get_filesystem_root("bessd")
-        (self.root / "etc/bess/conf").mkdir(parents=True)
-        
+
     @pytest.fixture(autouse=True)
     def harness(self, setUp, request):
         self.harness = testing.Harness(UPFOperatorCharm)
         self.harness.set_model_name(name=NAMESPACE)
         self.harness.set_leader(is_leader=True)
-        #self.harness.begin()
         self.add_storage()
         yield self.harness
         self.harness.cleanup()
         request.addfinalizer(self.tearDown)
 
-    def test_given_bad_config_when_config_changed_then_status_is_blocked(self):
-        self.mock_client_list.side_effect = [
-            [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
-            [],
-            [],
+    def add_storage(self) -> None:
+        self.root = self.harness.get_filesystem_root("bessd")
+        (self.root / "etc/bess/conf").mkdir(parents=True)
+
+    @pytest.mark.parametrize(
+        "config_param,invalid_value",
+        [
+            pytest.param("dnn", "", id="empty_dnn"),
+            pytest.param("upf-mode", "", id="empty_upf_mode"),
+            pytest.param("upf-mode", "unsupported", id="unsupported_upf_mode"),
         ]
-        self.harness.update_config(key_values={"dnn": ""})
-        self.harness.begin()
-        self.harness.evaluate_status()
-        
-        assert self.harness.model.unit.status == BlockedStatus("The following configurations are not valid: ['dnn']")
-
-    def test_given_empty_upf_mode_when_config_changed_then_status_is_blocked(self):
-        self.mock_client_list.side_effect = [
-            [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
-            [],
-            [],
-        ]
-        self.harness.update_config(key_values={"upf-mode": ""})
-        self.harness.begin()
-        self.harness.evaluate_status()
-
-        assert self.harness.model.unit.status == BlockedStatus("The following configurations are not valid: ['upf-mode']")
-
-    def test_given_unsupported_upf_mode_when_config_changed_then_status_is_blocked(
-        self
+    )
+    def test_given_bad_config_when_config_changed_then_status_is_blocked(
+        self, config_param, invalid_value
     ):
+        self.mock_huge_pages_is_enabled.return_value = True
         self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
-            [],
-            [],
         ]
-        self.harness.update_config(key_values={"upf-mode": "unsupported"})
-        self.harness.begin()
-        self.harness.evaluate_status()
-
-        assert self.harness.model.unit.status == BlockedStatus("The following configurations are not valid: ['upf-mode']")
-
-    def test_given_upf_mode_set_to_dpdk_but_other_required_configs_not_set_when_config_changed_then_status_is_blocked(  # noqa: E501
-        self
-    ):
-        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        self.mock_client_list.side_effect = [
-            [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
-            [],
-            [],
-        ]
-        self.harness.update_config(key_values={"cni-type": "vfioveth", "upf-mode": "dpdk"})
+        self.harness.update_config(key_values={config_param: invalid_value})
         self.harness.begin()
         self.harness.evaluate_status()
 
         assert self.harness.model.unit.status == BlockedStatus(
-                "The following configurations are not valid: ['access-interface-mac-address', 'core-interface-mac-address']"  # noqa: E501, W505
-            )
+            f"The following configurations are not valid: ['{config_param}']"
+        )
 
     def test_given_upf_mode_set_to_dpdk_and_hugepages_enabled_but_mac_addresses_of_access_and_core_interfaces_not_set_when_config_changed_then_status_is_blocked(  # noqa: E501
         self
     ):
-        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        self.mock_huge_pages_is_enabled.return_value = True
+        self.mock_cpu_info.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
         self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -180,12 +143,27 @@ class TestCharmInitialisation:
 
         assert self.harness.model.unit.status == BlockedStatus(
                 "The following configurations are not valid: ['access-interface-mac-address', 'core-interface-mac-address']"  # noqa: E501, W505
-            )
+        )
 
-    def test_given_upf_mode_set_to_dpdk_and_hugepages_enabled_but_access_interface_mac_addresses_is_invalid_when_config_changed_then_status_is_blocked(  # noqa: E501
-        self
+    @pytest.mark.parametrize(
+        "access_mac_address, core_mac_address, invalid_param_name",
+        [
+            pytest.param(
+                INVALID_ACCESS_MAC, VALID_CORE_MAC, "access-interface-mac-address", id="invalid_access_mac"  # noqa: E501
+            ),
+            pytest.param(
+                VALID_ACCESS_MAC, INVALID_CORE_MAC, "core-interface-mac-address", id="invalid_core_mac"  # noqa: E501
+            ),
+            pytest.param(
+                INVALID_ACCESS_MAC, INVALID_CORE_MAC, "access-interface-mac-address', 'core-interface-mac-address", id="invalid_access_and_core_mac"  # noqa: E501
+            )
+        ]
+    )
+    def test_given_upf_mode_set_to_dpdk_and_hugepages_enabled_but_mac_address_is_invalid_when_config_changed_then_status_is_blocked(  # noqa: E501
+        self, access_mac_address, core_mac_address, invalid_param_name
     ):
-        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        self.mock_huge_pages_is_enabled.return_value = True
+        self.mock_cpu_info.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
         self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -195,7 +173,27 @@ class TestCharmInitialisation:
             key_values={
                 "cni-type": "vfioveth",
                 "upf-mode": "dpdk",
-                "access-interface-mac-address": INVALID_ACCESS_MAC,
+                "access-interface-mac-address": access_mac_address,
+                "core-interface-mac-address": core_mac_address,
+            }
+        )
+        self.harness.begin()
+        self.harness.evaluate_status()
+
+        assert self.harness.model.unit.status == BlockedStatus(
+                f"The following configurations are not valid: ['{invalid_param_name}']"
+        )
+
+    def test_given_cpu_not_supporting_required_hugepages_instructions_when_hugepages_enabled_then_charm_goes_to_blocked_status(  # noqa: E501
+        self
+    ):
+        self.mock_huge_pages_is_enabled.return_value = False
+        self.mock_cpu_info.return_value = b"Flags: ssse3 fma cx16 rdrand"
+        self.harness.update_config(
+            key_values={
+                "cni-type": "vfioveth",
+                "upf-mode": "dpdk",
+                "access-interface-mac-address": VALID_ACCESS_MAC,
                 "core-interface-mac-address": VALID_CORE_MAC,
             }
         )
@@ -203,89 +201,69 @@ class TestCharmInitialisation:
         self.harness.evaluate_status()
 
         assert self.harness.model.unit.status == BlockedStatus(
-                "The following configurations are not valid: ['access-interface-mac-address']"
-            )
+            "CPU is not compatible, see logs for more details"
+        )
 
-    def test_given_upf_mode_set_to_dpdk_and_hugepages_enabled_but_core_interface_mac_addresses_is_invalid_when_config_changed_then_status_is_blocked(  # noqa: E501
-        self
-    ):
-        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        self.mock_client_list.side_effect = [
-            [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
-            [],
-            [],
+    @pytest.mark.parametrize(
+        "access_mtu_size, core_mtu_size, invalid_param_name",
+            [
+            pytest.param(
+                ZERO_MTU_SIZE, VALID_MTU_SIZE_2, "access-interface-mtu-size", id="zero_mtu_size_access_interface"  # noqa: E501
+            ),
+            pytest.param(
+                TOO_SMALL_MTU_SIZE, VALID_MTU_SIZE_2, "access-interface-mtu-size", id="too_small_mtu_size_access_interface"  # noqa: E501
+            ),
+            pytest.param(
+                VALID_MTU_SIZE_1, ZERO_MTU_SIZE, "core-interface-mtu-size", id="zero_mtu_size_core_interface"  # noqa: E501
+            ),
+            pytest.param(
+                VALID_MTU_SIZE_1, TOO_BIG_MTU_SIZE, "core-interface-mtu-size", id="too_big_mtu_size_core_interface"  # noqa: E501
+            ),
+            pytest.param(
+                ZERO_MTU_SIZE, ZERO_MTU_SIZE, "access-interface-mtu-size', 'core-interface-mtu-size", id="zero_mtu_size_access_and_core_interface"  # noqa: E501
+            )
         ]
+    )
+    def test_given_default_config_with_interfaces_invalid_mtu_sizes_when_network_attachment_definitions_from_config_is_called_then_status_is_blocked(  # noqa: E501
+        self, access_mtu_size, core_mtu_size, invalid_param_name
+    ):
+        self.mock_huge_pages_is_enabled.return_value = True
         self.harness.update_config(
             key_values={
-                "cni-type": "vfioveth",
-                "upf-mode": "dpdk",
-                "access-interface-mac-address": VALID_ACCESS_MAC,
-                "core-interface-mac-address": INVALID_CORE_MAC,
+                "access-interface-mtu-size": access_mtu_size,
+                "core-interface-mtu-size": core_mtu_size,
             }
         )
         self.harness.begin()
         self.harness.evaluate_status()
 
         assert self.harness.model.unit.status == BlockedStatus(
-                "The following configurations are not valid: ['core-interface-mac-address']"
-            )
-
-    #@patch("charm.Client", new=Mock)
-    def test_given_cpu_not_supporting_required_hugepages_instructions_when_hugepages_enabled_then_charm_goes_to_blocked_status(  # noqa: E501
-        self
-    ):
-        self.mock_is_patched.return_value = False
-        self.mock_check_output.return_value = b"Flags: ssse3 fma cx16 rdrand"
-        self.harness.update_config(
-            key_values={
-                "cni-type": "vfioveth",
-                "upf-mode": "dpdk",
-                "access-interface-mac-address": "00-B0-D0-63-C2-26",
-                "core-interface-mac-address": "00-B0-D0-63-C2-26",
-            }
-        )
-        self.harness.begin()
-        self.harness.evaluate_status()
-
-        assert self.harness.model.unit.status == BlockedStatus("CPU is not compatible, see logs for more details")
-
-    def test_given_default_config_with_interfaces_zero_mtu_sizes_when_network_attachment_definitions_from_config_is_called_then_status_is_blocked(  # noqa: E501
-        self
-    ):
-        self.harness.update_config(
-            key_values={
-                "access-interface-mtu-size": ZERO_MTU_SIZE,
-                "core-interface-mtu-size": ZERO_MTU_SIZE,
-            }
-        )
-        self.harness.begin()
-        self.harness.evaluate_status()
-
-        assert self.harness.model.unit.status == BlockedStatus(
-                "The following configurations are not valid: ['access-interface-mtu-size', 'core-interface-mtu-size']"  # noqa: E501, W505
+                f"The following configurations are not valid: ['{invalid_param_name}']"
         )
 
-    #@patch("ops.model.Container.get_service")
-    #@patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
     def test_given_container_can_connect_bessd_pebble_ready_when_core_net_mtu_config_changed_to_an_invalid_value_then_delete_pod_is_not_called(  # noqa: E501
         self
     ):
-        self.harness.handle_exec("bessd", [], result=0)
+        self.mock_huge_pages_is_enabled.return_value = True
         self.mock_multus_is_ready.return_value = True
+        self.harness.handle_exec("bessd", [], result=0)
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         self.harness.begin()
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
         update_nad_labels(original_nads, self.harness.charm.app.name)
         self.mock_list_na_definitions.return_value = original_nads
+
         self.harness.update_config(key_values={"core-interface-mtu-size": TOO_BIG_MTU_SIZE})
+
         self.mock_delete_pod.assert_not_called()
-    """
-    #@patch("ops.model.Container.get_service")
-    #@patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
+
     def test_given_hardware_checksum_is_enabled_when_bessd_pebble_ready_then_config_file_has_hwcksum_enabled(  # noqa: E501
         self,
     ):
+        self.mock_cpu_info.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        self.mock_multus_is_ready.return_value = True
+        self.mock_huge_pages_is_enabled.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
@@ -296,7 +274,7 @@ class TestCharmInitialisation:
         config = json.loads((self.root / "etc/bess/conf/upf.json").read_text())
         assert "hwcksum" in config
         assert config["hwcksum"] is False
-    """
+
     def test_given_default_config_with_interfaces_when_network_attachment_definitions_from_config_is_called_then_interfaces_specified_in_nad(  # noqa: E501
         self,
     ):
@@ -320,59 +298,28 @@ class TestCharmInitialisation:
             assert (ACCESS_INTERFACE_NAME or CORE_INTERFACE_NAME in config["master"])
             assert config["type"] == "macvlan"
 
+class TestCharm(unittest.TestCase):
 
-class TestCharm:
-    
-    patcher_k8s_client = patch("lightkube.core.client.GenericSyncClient")
-    patcher_get_service = patch("ops.model.Container.get_service")
-    patcher_multus_is_ready = patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    patcher_is_patched = patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    patcher_publish_upf_information = patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
-    patcher_publish_upf_n4_information = patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
-    patcher_pfcp_port = patch("charm.PFCP_PORT", TEST_PFCP_PORT)
-    patcher_lightkube_client_get = patch("lightkube.core.client.Client.get")
-    patcher_client_list = patch("lightkube.core.client.Client.list")
-    patcher_client_create = patch("lightkube.core.client.Client.create")
-    patcher_dpdk_is_configured = patch("charm.DPDK.is_configured")
-    patcher_k8s_statefulset_patch = patch("lightkube.core.client.Client.patch")
-    patcher_check_output = patch("charm.check_output")
-    patcher_charm_client = patch("charm.Client")
-    @pytest.fixture()
     def setUp(self):
-        self.mock_k8s_client = TestCharm.patcher_k8s_client.start()
-        self.mock_get_service = TestCharm.patcher_get_service.start()
-        self.mock_multus_is_ready = TestCharm.patcher_multus_is_ready.start()
-        self.mock_is_patched = TestCharm.patcher_is_patched.start()
-        self.mock_publish_upf_information = TestCharm.patcher_publish_upf_information.start()
-        self.mock_publish_upf_n4_information = TestCharm.patcher_publish_upf_n4_information.start()
-        self.mock_pfcp_port = TestCharm.patcher_pfcp_port.start()
-        self.mock_lightkube_client_get = TestCharm.patcher_lightkube_client_get.start()
-        self.mock_client_list = TestCharm.patcher_client_list.start()
-        self.mock_client_create = TestCharm.patcher_client_create.start()
-        self.mock_dpdk_is_configured = TestCharm.patcher_dpdk_is_configured.start()
-        self.mock_k8s_statefulset_patch = TestCharm.patcher_k8s_statefulset_patch.start()
-        
-    def add_storage(self) -> None:
+        self.patch_k8s_client = patch("lightkube.core.client.GenericSyncClient")
+        self.patch_k8s_client.start()
+        self.namespace = "whatever"
+        self.harness = testing.Harness(UPFOperatorCharm)
+        self.harness.set_model_name(name=self.namespace)
+        self.harness.set_leader(is_leader=True)
+
+        self.maxDiff = None
         self.root = self.harness.get_filesystem_root("bessd")
         (self.root / "etc/bess/conf").mkdir(parents=True)
-        
-    @staticmethod
-    def tearDown() -> None:
-        patch.stopall()
-        
-    @pytest.fixture(autouse=True)
-    def harness(self, setUp, request):
-        self.harness = testing.Harness(UPFOperatorCharm)
-        self.harness.set_model_name(name=NAMESPACE)
-        self.harness.set_leader(is_leader=True)
-        self.add_storage()
+        self.addCleanup(self.harness.cleanup)
         self.harness.begin()
-        yield self.harness
-        self.harness.cleanup()
-        request.addfinalizer(self.tearDown)
 
+    @patch("ops.model.Container.get_service")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bessd_config_file_not_yet_written_when_bessd_pebble_ready_then_config_file_is_written(  # noqa: E501
-        self
+        self,
+        _,
+        __,
     ):
         self.harness.handle_exec("bessd", [], result=0)
         self.harness.set_can_connect("bessd", True)
@@ -380,10 +327,14 @@ class TestCharm:
         self.harness.container_pebble_ready(container_name="bessd")
         expected_config_file_content = read_file("tests/unit/expected_upf.json").strip()
 
-        assert (self.root / "etc/bess/conf/upf.json").read_text() == expected_config_file_content
+        self.assertEqual(
+            (self.root / "etc/bess/conf/upf.json").read_text(), expected_config_file_content
+        )
 
+    @patch("ops.model.Container.get_service")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bessd_config_file_not_yet_written_when_config_storage_attached_then_config_file_is_written(  # noqa: E501
-        self
+        self, _, __
     ):
         self.harness.handle_exec("bessd", [], result=0)
         self.harness.set_can_connect("bessd", True)
@@ -394,22 +345,30 @@ class TestCharm:
 
         expected_config_file_content = read_file("tests/unit/expected_upf.json").strip()
 
-        assert (self.root / "etc/bess/conf/upf.json").read_text() == expected_config_file_content
+        self.assertEqual(
+            (self.root / "etc/bess/conf/upf.json").read_text(), expected_config_file_content
+        )
 
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bessd_config_file_matches_when_bessd_pebble_ready_then_config_file_is_not_changed(  # noqa: E501
-        self
+        self,
+        patch_is_ready,
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        self.mock_multus_is_ready.return_value = True
+        patch_is_ready.return_value = True
         expected_upf_content = read_file("tests/unit/expected_upf.json").strip()
         (self.root / "etc/bess/conf/upf.json").write_text(expected_upf_content)
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        assert (self.root / "etc/bess/conf/upf.json").read_text() == expected_upf_content
+        self.assertEqual((self.root / "etc/bess/conf/upf.json").read_text(), expected_upf_content)
 
+    @patch("ops.model.Container.get_service")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bess_configured_when_bessd_pebble_ready_then_expected_pebble_plan_is_applied(  # noqa: E501
-        self
+        self,
+        patch_is_ready,
+        _,
     ):
         grpc_check_cmd = "/opt/bess/bessctl/bessctl show version".split()
         accessRoutes_check_cmd = "/opt/bess/bessctl/bessctl show module accessRoutes".split()  # noqa: N806
@@ -426,7 +385,7 @@ class TestCharm:
         self.harness.handle_exec("bessd", bessctl_cmd, result=0)
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        self.mock_multus_is_ready.return_value = True
+        patch_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
         expected_plan = {
@@ -461,10 +420,14 @@ class TestCharm:
 
         updated_plan = self.harness.get_container_pebble_plan("bessd").to_dict()
 
-        assert expected_plan == updated_plan
+        self.assertEqual(expected_plan, updated_plan)
 
+    @patch("ops.model.Container.get_service")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bess_not_configured_when_bessd_pebble_ready_then_routectl_service_not_started(  # noqa: E501
-        self
+        self,
+        patch_is_ready,
+        _,
     ):
         grpc_check_cmd = "/opt/bess/bessctl/bessctl show version".split()
         accessRoutes_check_cmd = "/opt/bess/bessctl/bessctl show module accessRoutes".split()  # noqa: N806
@@ -481,14 +444,16 @@ class TestCharm:
         self.harness.handle_exec("bessd", bessctl_cmd, result=0)
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        self.mock_multus_is_ready.return_value = True
+        patch_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        assert "routectl" not in self.harness.get_container_pebble_plan("bessd").services
+        self.assertNotIn("routectl", self.harness.get_container_pebble_plan("bessd").services)
 
+    @patch("ops.model.Container.get_service")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_can_connect_to_bessd_when_bessd_pebble_ready_then_ip_route_is_created(
-        self
+        self, patch_is_ready, _
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
@@ -523,16 +488,18 @@ class TestCharm:
         self.harness.handle_exec("bessd", ["iptables-legacy"], result=0)
         self.harness.handle_exec("bessd", ["/opt/bess/bessctl/bessctl"], result=0)
         self.harness.handle_exec("bessd", ip_route_show_cmd, result="")
-        self.mock_multus_is_ready.return_value = True
+        patch_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        assert ip_route_replace_called
-        assert timeout == 30
-        assert environment == {}
+        self.assertTrue(ip_route_replace_called)
+        self.assertEqual(timeout, 30)
+        self.assertEqual(environment, {})
 
+    @patch("ops.model.Container.get_service")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_can_connect_to_bessd_when_bessd_pebble_ready_then_gnb_subnet_route_is_created(
-        self
+        self, patch_is_ready, _
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
@@ -567,16 +534,18 @@ class TestCharm:
         self.harness.handle_exec("bessd", ["iptables-legacy"], result=0)
         self.harness.handle_exec("bessd", ["/opt/bess/bessctl/bessctl"], result=0)
         self.harness.handle_exec("bessd", ip_route_show_cmd, result="")
-        self.mock_multus_is_ready.return_value = True
+        patch_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        assert gnb_subnet_route_replace_called
-        assert timeout == 30
-        assert environment == {}
+        self.assertTrue(gnb_subnet_route_replace_called)
+        self.assertEqual(timeout, 30)
+        self.assertEqual(environment, {})
 
+    @patch("ops.model.Container.get_service")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_iptables_rule_is_not_yet_created_when_bessd_pebble_ready_then_rule_is_created(
-        self
+        self, patch_is_ready, _
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
@@ -620,16 +589,17 @@ class TestCharm:
         self.harness.handle_exec("bessd", iptables_check_cmd, result=1)
         self.harness.handle_exec("bessd", iptables_drop_cmd, handler=iptables_handler)
         self.harness.handle_exec("bessd", ["/opt/bess/bessctl/bessctl"], result=0)
-        self.mock_multus_is_ready.return_value = True
+        patch_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
-        
-        assert iptables_drop_called
-        assert timeout == 30
-        assert environment == {}
+        self.assertTrue(iptables_drop_called)
+        self.assertEqual(timeout, 30)
+        self.assertEqual(environment, {})
 
+    @patch("ops.model.Container.get_service")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_iptables_rule_is_created_when_bessd_pebble_ready_then_rule_is_not_re_created(
-        self
+        self, patch_is_ready, _
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
@@ -656,12 +626,12 @@ class TestCharm:
         self.harness.handle_exec("bessd", iptables_drop_cmd, handler=iptables_handler)
         self.harness.handle_exec("bessd", ["iptables-legacy"], result=0)
         self.harness.handle_exec("bessd", ["/opt/bess/bessctl/bessctl"], result=0)
-        self.mock_multus_is_ready.return_value = True
+        patch_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        assert not iptables_drop_called
-    """
+        self.assertFalse(iptables_drop_called)
+
     @parameterized.expand(
         [
             [1, 0, "RUNNING"],
@@ -672,7 +642,7 @@ class TestCharm:
     @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_can_connect_to_bessd_when_bessd_pebble_ready_then_bessctl_configure_is_executed(
-        self, accessRoutes_check_out, coreRoutes_check_out, config_check_out, self.mock_multus_is_ready, _  # noqa: N803
+        self, accessRoutes_check_out, coreRoutes_check_out, config_check_out, patch_is_ready, _  # noqa: N803
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
@@ -702,7 +672,7 @@ class TestCharm:
         self.harness.handle_exec("bessd", coreRoutes_check_cmd, result=coreRoutes_check_out)
         self.harness.handle_exec("bessd", config_check_cmd, result=config_check_out)
         self.harness.handle_exec("bessd", bessctl_cmd, handler=bessctl_handler)
-        self.mock_multus_is_ready.return_value = True
+        patch_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
@@ -711,10 +681,11 @@ class TestCharm:
         self.assertEqual(
             environment, {"CONF_FILE": "/etc/bess/conf/upf.json", "PYTHONPATH": "/opt/bess"}
         )
-    """
 
+    @patch("ops.model.Container.get_service")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_connects_and_bess_configured_then_bessctl_configure_not_executed(
-        self
+        self, patch_is_ready, _
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
@@ -739,40 +710,54 @@ class TestCharm:
         self.harness.handle_exec("bessd", coreRoutes_check_cmd, result=0)
         self.harness.handle_exec("bessd", config_check_cmd, result="RUNNING")
         self.harness.handle_exec("bessd", bessctl_cmd, handler=bessctl_handler)
-        self.mock_multus_is_ready.return_value = True
+        patch_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        assert not bessctl_called
+        self.assertFalse(bessctl_called)
 
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_storage_not_attached_when_bessd_pebble_ready_then_status_is_waiting(
-        self
+        self,
+        patch_is_ready,
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
         ip_route_show_result = f"{GNB_SUBNET} via {ACCESS_GW_IP}\ndefault via {CORE_GW_IP}"
 
         self.harness.handle_exec("bessd", ip_route_show_cmd, result=ip_route_show_result)
         self.harness.handle_exec("bessd", [], result=0)
-        self.mock_multus_is_ready.return_value = True
+        patch_is_ready.return_value = True
         (self.root / "etc/bess/conf").rmdir()
 
         self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == WaitingStatus("Waiting for storage to be attached")
+        self.assertEqual(
+            self.harness.model.unit.status,
+            WaitingStatus("Waiting for storage to be attached"),
+        )
 
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_multus_not_configured_when_bessd_pebble_ready_then_status_is_waiting(
         self,
+        patch_is_ready,
     ):
-        self.mock_multus_is_ready.return_value = False
+        patch_is_ready.return_value = False
 
         self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == WaitingStatus("Waiting for Multus to be ready")
+        self.assertEqual(
+            self.harness.model.unit.status,
+            WaitingStatus("Waiting for Multus to be ready"),
+        )
 
+    @patch("ops.model.Container.get_service")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_config_file_is_written_and_all_services_are_running_when_bessd_pebble_ready_then_status_is_active(  # noqa: E501
         self,
+        patch_is_ready,
+        patch_get_service,
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
         ip_route_show_result = f"{GNB_SUBNET} via {ACCESS_GW_IP}\ndefault via {CORE_GW_IP}"
@@ -781,22 +766,26 @@ class TestCharm:
         self.harness.handle_exec("bessd", [], result="RUNNING")
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
-        self.mock_multus_is_ready.return_value = True
+        patch_get_service.return_value = service_info_mock
+        patch_is_ready.return_value = True
         self.harness.set_can_connect(container="pfcp-agent", val=True)
 
         self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == ActiveStatus()
+        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
 
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
+    @patch("ops.model.Container.get_service")
     def test_given_bessd_service_is_running_when_pfcp_agent_pebble_ready_then_pebble_plan_is_applied(  # noqa: E501
-        self
+        self,
+        patch_get_service,
+        patch_multus_is_ready,
     ):
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
-        self.mock_multus_is_ready.return_value = True
+        patch_get_service.return_value = service_info_mock
+        patch_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         grpc_check_cmd = "/opt/bess/bessctl/bessctl show version".split()
         accessRoutes_check_cmd = "/opt/bess/bessctl/bessctl show module accessRoutes".split()  # noqa: N806
@@ -813,7 +802,7 @@ class TestCharm:
 
         self.harness.container_pebble_ready(container_name="pfcp-agent")
         self.harness.evaluate_status()
-        assert self.harness.charm.unit.status == ActiveStatus()
+        self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
 
         expected_plan = {
             "services": {
@@ -827,81 +816,99 @@ class TestCharm:
 
         updated_plan = self.harness.get_container_pebble_plan("pfcp-agent").to_dict()
 
-        assert expected_plan == updated_plan
+        self.assertEqual(expected_plan, updated_plan)
 
     def test_given_cant_connect_to_bessd_container_when_pfcp_agent_pebble_ready_then_status_is_waiting(  # noqa: E501
-        self
+        self,
     ):
         self.harness.set_can_connect(container="bessd", val=False)
 
         self.harness.container_pebble_ready(container_name="pfcp-agent")
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == WaitingStatus("Waiting for bessd container to be ready")
+        self.assertEqual(
+            self.harness.model.unit.status,
+            WaitingStatus("Waiting for bessd container to be ready"),
+        )
 
+    @patch("ops.model.Container.get_service")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_pebble_connection_error_when_bessd_pebble_ready_then_status_is_waiting(  # noqa: E501
-        self
+        self, patch_is_ready, patch_get_service
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
         ip_route_show_result = f"{GNB_SUBNET} via {ACCESS_GW_IP}\ndefault via {CORE_GW_IP}"
 
         self.harness.handle_exec("bessd", ip_route_show_cmd, result=ip_route_show_result)
         self.harness.handle_exec("bessd", [], result=0)
-        self.mock_get_service.side_effect = ConnectionError()
-        self.mock_multus_is_ready.return_value = True
+        patch_get_service.side_effect = ConnectionError()
+        patch_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
 
         self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == WaitingStatus("Waiting for bessd service to run")
+        self.assertEqual(
+            self.harness.model.unit.status, WaitingStatus("Waiting for bessd service to run")
+        )
 
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_default_route_not_created_when_bessd_pebble_ready_then_status_is_waiting(
-        self
+        self, patch_is_ready
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
 
         self.harness.handle_exec("bessd", ip_route_show_cmd, result="")
         self.harness.handle_exec("bessd", [], result=0)
-        self.mock_multus_is_ready.return_value = True
+        patch_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
 
         self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == WaitingStatus("Waiting for default route creation")
+        self.assertEqual(
+            self.harness.model.unit.status, WaitingStatus("Waiting for default route creation")
+        )
 
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_ran_route_not_created_when_bessd_pebble_ready_then_status_is_waiting(
-        self,
+        self, patch_is_ready
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
 
         self.harness.handle_exec("bessd", ip_route_show_cmd, result=f"default via {CORE_GW_IP}")
         self.harness.handle_exec("bessd", [], result=0)
-        self.mock_multus_is_ready.return_value = True
+        patch_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
 
         self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == WaitingStatus("Waiting for RAN route creation")
+        self.assertEqual(
+            self.harness.model.unit.status, WaitingStatus("Waiting for RAN route creation")
+        )
 
+    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
     def test_given_fiveg_n3_relation_created_when_fiveg_n3_request_then_upf_ip_address_is_published(  # noqa: E501
-        self
+        self,
+        patched_publish_upf_information,
+        patch_hugepages_is_patched,
     ):
-        self.mock_is_patched.return_value = True
+        patch_hugepages_is_patched.return_value = True
         test_upf_access_ip_cidr = "1.2.3.4/21"
         self.harness.update_config(key_values={"access-ip": test_upf_access_ip_cidr})
 
         n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
         self.harness.add_relation_unit(n3_relation_id, "n3_requirer_app/0")
 
-        self.mock_publish_upf_information.assert_called_once_with(
+        patched_publish_upf_information.assert_called_once_with(
             relation_id=n3_relation_id, upf_ip_address=test_upf_access_ip_cidr.split("/")[0]
         )
 
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
     def test_given_unit_is_not_leader_when_fiveg_n3_request_then_upf_ip_address_is_not_published(
-        self
+        self, patched_publish_upf_information
     ):
         self.harness.set_leader(is_leader=False)
         test_upf_access_ip_cidr = "1.2.3.4/21"
@@ -910,15 +917,23 @@ class TestCharm:
         n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
         self.harness.add_relation_unit(n3_relation_id, "n3_requirer_app/0")
 
-        self.mock_publish_upf_information.assert_not_called()
+        patched_publish_upf_information.assert_not_called()
 
-    #@patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
+    @patch("ops.model.Container.get_service")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
+    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_fiveg_n3_relation_exists_when_access_ip_config_changed_then_new_upf_ip_address_is_published(  # noqa: E501
-        self
+        self,
+        patch_multus_is_ready,
+        patch_hugepages_is_patched,
+        patched_publish_upf_information,
+        _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        self.mock_multus_is_ready.return_value = True
-        self.mock_is_patched.return_value = True
+        patch_multus_is_ready.return_value = True
+        patch_hugepages_is_patched.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
@@ -931,13 +946,15 @@ class TestCharm:
 
         self.harness.update_config(key_values={"access-ip": test_upf_access_ip_cidr})
 
-        self.mock_publish_upf_information.assert_has_calls(expected_calls)
+        patched_publish_upf_information.assert_has_calls(expected_calls)
 
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_fiveg_n3_relation_exists_when_access_ip_config_changed_to_invalid_cidr_then_new_upf_ip_address_is_not_published(  # noqa: E501
-        self
+        self, patch_multus_is_ready, patched_publish_upf_information
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        self.mock_multus_is_ready.return_value = True
+        patch_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
@@ -946,12 +963,13 @@ class TestCharm:
 
         self.harness.update_config(key_values={"access-ip": invalid_test_upf_access_ip_cidr})
 
-        self.mock_publish_upf_information.assert_called_once_with(
+        patched_publish_upf_information.assert_called_once_with(
             relation_id=n3_relation_id, upf_ip_address="192.168.252.3"
         )
 
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
     def test_given_unit_is_not_leader_when_fiveg_n4_request_then_upf_hostname_is_not_published(
-        self
+        self, patched_publish_upf_n4_information
     ):
         self.harness.set_leader(is_leader=False)
         test_external_upf_hostname = "test-upf.external.hostname.com"
@@ -962,12 +980,17 @@ class TestCharm:
         n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
         self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
 
-        self.mock_publish_upf_n4_information.assert_not_called()
+        patched_publish_upf_n4_information.assert_not_called()
 
+    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
+    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_set_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
-        self
+        self,
+        patched_publish_upf_n4_information,
+        patch_hugepages_is_patched,
     ):
-        self.mock_is_patched.return_value = True
+        patch_hugepages_is_patched.return_value = True
         test_external_upf_hostname = "test-upf.external.hostname.com"
         self.harness.update_config(
             key_values={"external-upf-hostname": test_external_upf_hostname}
@@ -976,14 +999,17 @@ class TestCharm:
         n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
         self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
 
-        self.mock_publish_upf_n4_information.assert_called_once_with(
+        patched_publish_upf_n4_information.assert_called_once_with(
             relation_id=n4_relation_id,
             upf_hostname=test_external_upf_hostname,
             upf_n4_port=TEST_PFCP_PORT,
         )
 
+    @patch("lightkube.core.client.Client.get")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
+    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_not_set_but_external_upf_service_hostname_available_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
-        self
+        self, patched_publish_upf_n4_information, patched_lightkube_client_get
     ):
         test_external_upf_service_hostname = "test-upf.external.service.hostname.com"
         service = Mock(
@@ -993,56 +1019,71 @@ class TestCharm:
                 )
             )
         )
-        self.mock_lightkube_client_get.return_value = service
+        patched_lightkube_client_get.return_value = service
 
         n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
         self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
 
-        self.mock_publish_upf_n4_information.assert_called_once_with(
+        patched_publish_upf_n4_information.assert_called_once_with(
             relation_id=n4_relation_id,
             upf_hostname=test_external_upf_service_hostname,
             upf_n4_port=TEST_PFCP_PORT,
         )
 
+    @patch("lightkube.core.client.Client.get")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
+    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_not_set_and_external_upf_service_hostname_not_available_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
-        self,
+        self, patched_publish_upf_n4_information, patched_lightkube_client_get
     ):
         service = Mock(status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", spec=["ip"])])))
-        self.mock_lightkube_client_get.return_value = service
+        patched_lightkube_client_get.return_value = service
 
         n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
         self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
 
-        self.mock_publish_upf_n4_information.assert_called_once_with(
+        patched_publish_upf_n4_information.assert_called_once_with(
             relation_id=n4_relation_id,
-            upf_hostname=f"{self.harness.charm.app.name}-external.{NAMESPACE}"
+            upf_hostname=f"{self.harness.charm.app.name}-external.{self.namespace}"
             ".svc.cluster.local",
             upf_n4_port=TEST_PFCP_PORT,
         )
 
+    @patch("lightkube.core.client.Client.get")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
+    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_not_set_and_metallb_not_available_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
-        self
+        self, patched_publish_upf_n4_information, patched_lightkube_client_get
     ):
         service = Mock(status=Mock(loadBalancer=Mock(ingress=None)))
-        self.mock_lightkube_client_get.return_value = service
+        patched_lightkube_client_get.return_value = service
 
         n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
         self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
 
-        self.mock_publish_upf_n4_information.assert_called_once_with(
+        patched_publish_upf_n4_information.assert_called_once_with(
             relation_id=n4_relation_id,
-            upf_hostname=f"{self.harness.charm.app.name}-external.{NAMESPACE}"
+            upf_hostname=f"{self.harness.charm.app.name}-external.{self.namespace}"
             ".svc.cluster.local",
             upf_n4_port=TEST_PFCP_PORT,
         )
 
+    @patch("ops.model.Container.get_service")
+    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
+    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
+    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_fiveg_n4_relation_exists_when_external_upf_hostname_config_changed_then_new_upf_hostname_is_published(  # noqa: E501
-        self
+        self,
+        patch_multus_is_ready,
+        patch_hugepages_is_ready,
+        patched_publish_upf_n4_information,
+        _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
         test_external_upf_hostname = "test-upf.external.hostname.com"
-        self.mock_multus_is_ready.return_value = True
-        self.mock_is_patched.return_value = True
+        patch_multus_is_ready.return_value = True
+        patch_hugepages_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         self.harness.update_config(key_values={"external-upf-hostname": "whatever.com"})
@@ -1063,12 +1104,14 @@ class TestCharm:
             key_values={"external-upf-hostname": test_external_upf_hostname}
         )
 
-        self.mock_publish_upf_n4_information.assert_has_calls(expected_calls)
+        patched_publish_upf_n4_information.assert_has_calls(expected_calls)
 
+    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_no_interface_specified_in_nad(  # noqa: E501
         self,
+        patch_hugepages_is_patched,
     ):
-        self.mock_is_patched.return_value = True
+        patch_hugepages_is_patched.return_value = True
         self.harness.update_config(
             key_values={
                 "access-ip": DEFAULT_ACCESS_IP,
@@ -1081,22 +1124,28 @@ class TestCharm:
         nads = self.harness.charm._network_attachment_definitions_from_config()
         for nad in nads:
             config = json.loads(nad.spec["config"])
-            assert "master" not in config
-            assert "bridge" == config["type"]
-            assert config["bridge"] in ("core-br", "access-br")
+            self.assertNotIn("master", config)
+            self.assertEqual("bridge", config["type"])
+            self.assertIn(config["bridge"], ("core-br", "access-br"))
 
+    @patch("lightkube.core.client.Client.create")
+    @patch("ops.model.Container.get_service")
+    @patch("lightkube.core.client.Client.list")
+    @patch(
+        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
+        Mock(return_value=True),
+    )
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
+    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_configured_to_run_in_dpdk_mode_when_create_network_attachment_definitions_then_2_nads_are_returned(  # noqa: E501
-        self,
+        self, patched_list, patch_get_service, kubernetes_create_object
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        self.mock_multus_is_ready.return_value = True
-        self.mock_is_patched.return_value = True
-        self.mock_dpdk_is_configured.return_value = True
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
-        self.mock_client_list.side_effect = [
+        patch_get_service.return_value = service_info_mock
+        patched_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1112,21 +1161,27 @@ class TestCharm:
             }
         )
 
-        create_nad_calls = self.mock_client_create.call_args_list
-        assert len(create_nad_calls) == 2
+        create_nad_calls = kubernetes_create_object.call_args_list
+        self.assertEqual(len(create_nad_calls), 2)
 
+    @patch("lightkube.core.client.Client.create")
+    @patch("ops.model.Container.get_service")
+    @patch("lightkube.core.client.Client.list")
+    @patch(
+        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
+        Mock(return_value=True),
+    )
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
+    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_configured_to_run_in_dpdk_mode_when_create_network_attachment_definitions_then_nad_type_is_vfioveth(  # noqa: E501
-        self
+        self, patched_list, patch_get_service, kubernetes_create_object
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
-        self.mock_dpdk_is_configured.return_value = True
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
-        self.mock_client_list.side_effect = [
+        patch_get_service.return_value = service_info_mock
+        patched_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
@@ -1141,26 +1196,32 @@ class TestCharm:
             }
         )
 
-        create_nad_calls = self.mock_client_create.call_args_list
+        create_nad_calls = kubernetes_create_object.call_args_list
         for create_nad_call in create_nad_calls:
             create_nad_call_args = next(
                 iter(filter(lambda call_item: isinstance(call_item, dict), create_nad_call))
             )
             nad_config = json.loads(create_nad_call_args.get("obj").spec.get("config"))
-            assert nad_config["type"] == "vfioveth"
+            self.assertEqual(nad_config["type"], "vfioveth")
 
+    @patch("lightkube.core.client.Client.create")
+    @patch("ops.model.Container.get_service")
+    @patch("lightkube.core.client.Client.list")
+    @patch(
+        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
+        Mock(return_value=True),
+    )
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
+    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_configured_to_run_in_dpdk_mode_when_create_network_attachment_definitions_then_access_nad_has_valid_dpdk_access_resource_specified_in_annotations(  # noqa: E501
-        self
+        self, patched_list, patch_get_service, kubernetes_create_object
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
-        self.mock_dpdk_is_configured.return_value = True
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
-        self.mock_client_list.side_effect = [
+        patch_get_service.return_value = service_info_mock
+        patched_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1189,28 +1250,37 @@ class TestCharm:
                 None,
             )
 
-        create_nad_calls = self.mock_client_create.mock_calls
+        create_nad_calls = kubernetes_create_object.mock_calls
         create_access_nad_calls = [
             _get_create_access_nad_call(create_nad_call)
             for create_nad_call in create_nad_calls
             if _get_create_access_nad_call(create_nad_call)
         ]
-        assert len(create_access_nad_calls) == 1
+        self.assertEqual(len(create_access_nad_calls), 1)
         nad_annotations = create_access_nad_calls[0].get("obj").metadata.annotations
-        assert DPDK_ACCESS_INTERFACE_RESOURCE_NAME in nad_annotations["k8s.v1.cni.cncf.io/resourceName"]
+        self.assertTrue(
+            DPDK_ACCESS_INTERFACE_RESOURCE_NAME
+            in nad_annotations["k8s.v1.cni.cncf.io/resourceName"]
+        )
 
+    @patch("lightkube.core.client.Client.create")
+    @patch("ops.model.Container.get_service")
+    @patch("lightkube.core.client.Client.list")
+    @patch(
+        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
+        Mock(return_value=True),
+    )
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
+    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_configured_to_run_in_dpdk_mode_when_create_network_attachment_definitions_then_core_nad_has_valid_dpdk_core_resource_specified_in_annotations(  # noqa: E501
-        self
+        self, patched_list, patch_get_service, kubernetes_create_object
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
-        self.mock_dpdk_is_configured.return_value = True
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
-        self.mock_client_list.side_effect = [
+        patch_get_service.return_value = service_info_mock
+        patched_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1239,30 +1309,37 @@ class TestCharm:
                 None,
             )
 
-        create_nad_calls = self.mock_client_create.mock_calls
+        create_nad_calls = kubernetes_create_object.mock_calls
         create_core_nad_calls = [
             _get_create_core_nad_call(create_nad_call)
             for create_nad_call in create_nad_calls
             if _get_create_core_nad_call(create_nad_call)
         ]
-        assert len(create_core_nad_calls) == 1
+        self.assertEqual(len(create_core_nad_calls), 1)
         nad_annotations = create_core_nad_calls[0].get("obj").metadata.annotations
-        assert DPDK_CORE_INTERFACE_RESOURCE_NAME in nad_annotations["k8s.v1.cni.cncf.io/resourceName"]
+        self.assertTrue(
+            DPDK_CORE_INTERFACE_RESOURCE_NAME in nad_annotations["k8s.v1.cni.cncf.io/resourceName"]
+        )
 
+    @patch("lightkube.core.client.Client.patch")
+    @patch("ops.model.Container.get_service")
+    @patch(
+        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
+        Mock(return_value=True),
+    )
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
+    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_patch_statefulset_then_2_network_annotations_are_created(  # noqa: E501
-        self
+        self, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
-        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
+        patch_get_service.return_value = service_info_mock
         self.harness.update_config()
-        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
+        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1278,22 +1355,27 @@ class TestCharm:
                 NetworkAnnotation.NETWORK_ANNOTATION_RESOURCE_KEY
             )
         )
-        assert len(network_annotations) == 2
+        self.assertEqual(len(network_annotations), 2)
 
+    @patch("lightkube.core.client.Client.patch")
+    @patch("ops.model.Container.get_service")
+    @patch(
+        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
+        Mock(return_value=True),
+    )
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
+    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_generate_network_annotations_is_called_then_access_network_annotation_created(  # noqa: E501
-        self,
+        self, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
-        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
+        patch_get_service.return_value = service_info_mock
         self.harness.update_config()
-        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
+        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1318,23 +1400,28 @@ class TestCharm:
                 )
             )
         )
-        assert access_network_annotation
-        assert access_network_annotation.get("interface") == ACCESS_INTERFACE_NAME
+        self.assertTrue(access_network_annotation)
+        self.assertEqual(access_network_annotation.get("interface"), ACCESS_INTERFACE_NAME)
 
+    @patch("lightkube.core.client.Client.patch")
+    @patch("ops.model.Container.get_service")
+    @patch(
+        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
+        Mock(return_value=True),
+    )
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
+    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_generate_network_annotations_is_called_then_access_network_annotation_created_without_dpdk_specific_data(  # noqa: E501
-        self
+        self, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
-        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
+        patch_get_service.return_value = service_info_mock
         self.harness.update_config()
-        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
+        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1359,23 +1446,28 @@ class TestCharm:
                 )
             )
         )
-        assert not access_network_annotation.get("mac")
-        assert not access_network_annotation.get("ips")
+        self.assertFalse(access_network_annotation.get("mac"))
+        self.assertFalse(access_network_annotation.get("ips"))
 
+    @patch("lightkube.core.client.Client.patch")
+    @patch("ops.model.Container.get_service")
+    @patch(
+        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
+        Mock(return_value=True),
+    )
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
+    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_generate_network_annotations_is_called_then_core_network_annotation_created(  # noqa: E501
-        self
+        self, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
-        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
+        patch_get_service.return_value = service_info_mock
         self.harness.update_config()
-        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
+        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1400,23 +1492,28 @@ class TestCharm:
                 )
             )
         )
-        assert access_network_annotation
-        assert access_network_annotation.get("interface") == CORE_INTERFACE_NAME
+        self.assertTrue(access_network_annotation)
+        self.assertEqual(access_network_annotation.get("interface"), CORE_INTERFACE_NAME)
 
+    @patch("lightkube.core.client.Client.patch")
+    @patch("ops.model.Container.get_service")
+    @patch(
+        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
+        Mock(return_value=True),
+    )
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
+    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_generate_network_annotations_is_called_then_core_network_annotation_created_without_dpdk_specific_data(  # noqa: E501
-        self,
+        self, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
-        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
+        patch_get_service.return_value = service_info_mock
         self.harness.update_config()
-        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
+        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1441,22 +1538,28 @@ class TestCharm:
                 )
             )
         )
-        assert not access_network_annotation.get("mac")
-        assert not access_network_annotation.get("ips")
+        self.assertFalse(access_network_annotation.get("mac"))
+        self.assertFalse(access_network_annotation.get("ips"))
 
+    @patch("lightkube.core.client.Client.patch")
+    @patch("ops.model.Container.get_service")
+    @patch("lightkube.core.client.Client.list")
+    @patch(
+        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
+        Mock(return_value=True),
+    )
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
+    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_dpdk_mode_when_patch_statefulset_then_2_network_annotations_are_created(  # noqa: E501
-        self,
+        self, patched_list, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
-        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
-        self.mock_client_list.side_effect = [
+        patch_get_service.return_value = service_info_mock
+        patched_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1471,7 +1574,7 @@ class TestCharm:
                 "core-interface-mac-address": VALID_CORE_MAC,
             }
         )
-        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
+        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1487,21 +1590,27 @@ class TestCharm:
                 NetworkAnnotation.NETWORK_ANNOTATION_RESOURCE_KEY
             )
         )
-        assert len(network_annotations) == 2
+        self.assertEqual(len(network_annotations), 2)
 
+    @patch("lightkube.core.client.Client.patch")
+    @patch("ops.model.Container.get_service")
+    @patch("lightkube.core.client.Client.list")
+    @patch(
+        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
+        Mock(return_value=True),
+    )
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
+    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_dpdk_mode_when_generate_network_annotations_is_called_then_access_network_annotation_created(  # noqa: E501
-        self,
+        self, patched_list, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
-        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
-        self.mock_client_list.side_effect = [
+        patch_get_service.return_value = service_info_mock
+        patched_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1517,7 +1626,7 @@ class TestCharm:
                 "core-interface-mac-address": VALID_CORE_MAC,
             }
         )
-        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
+        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1542,25 +1651,30 @@ class TestCharm:
                 )
             )
         )
-        assert access_network_annotation
-        assert access_network_annotation.get("interface") == ACCESS_INTERFACE_NAME
-        assert access_network_annotation.get("mac") == VALID_ACCESS_MAC
-        assert access_network_annotation.get("ips") == [VALID_ACCESS_IP]
+        self.assertTrue(access_network_annotation)
+        self.assertEqual(access_network_annotation.get("interface"), ACCESS_INTERFACE_NAME)
+        self.assertEqual(access_network_annotation.get("mac"), VALID_ACCESS_MAC)
+        self.assertEqual(access_network_annotation.get("ips"), [VALID_ACCESS_IP])
 
-
+    @patch("lightkube.core.client.Client.patch")
+    @patch("ops.model.Container.get_service")
+    @patch("lightkube.core.client.Client.list")
+    @patch(
+        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
+        Mock(return_value=True),
+    )
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
+    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_dpdk_mode_when_generate_network_annotations_is_called_then_core_network_annotation_created(  # noqa: E501
-        self,
+        self, patched_list, patch_get_service, kubernetes_statefulset_patch
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
-        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
-        self.mock_client_list.side_effect = [
+        patch_get_service.return_value = service_info_mock
+        patched_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1576,7 +1690,7 @@ class TestCharm:
                 "core-interface-mac-address": VALID_CORE_MAC,
             }
         )
-        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
+        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1601,40 +1715,45 @@ class TestCharm:
                 )
             )
         )
-        assert access_network_annotation
-        assert access_network_annotation.get("interface") == CORE_INTERFACE_NAME
-        assert access_network_annotation.get("mac") == VALID_CORE_MAC
-        assert access_network_annotation.get("ips") == [VALID_CORE_IP]
+        self.assertTrue(access_network_annotation)
+        self.assertEqual(access_network_annotation.get("interface"), CORE_INTERFACE_NAME)
+        self.assertEqual(access_network_annotation.get("mac"), VALID_CORE_MAC)
+        self.assertEqual(access_network_annotation.get("ips"), [VALID_CORE_IP])
 
+    @patch("charm.check_output")
+    @patch("charm.Client", new=Mock)
     def test_given_cpu_not_supporting_required_instructions_when_install_then_charm_goes_to_blocked_status(  # noqa: E501
-        self,
+        self, patched_check_output
     ):
-        self.mock_check_output = TestCharm.patcher_check_output.start()
-        self.mock_check_output.return_value = b"Flags: ssse3 fma cx16 rdrand"
+        patched_check_output.return_value = b"Flags: ssse3 fma cx16 rdrand"
         self.harness.charm.on.install.emit()
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == BlockedStatus("CPU is not compatible, see logs for more details")
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("CPU is not compatible, see logs for more details"),
+        )
 
+    @patch("charm.check_output")
+    @patch("charm.Client", new=Mock)
     def test_given_cpu_supporting_required_instructions_when_install_then_charm_goes_to_maintenance_status(  # noqa: E501
-        self,
+        self, patched_check_output
     ):
-        self.mock_check_output = TestCharm.patcher_check_output.start()
-        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand"
+        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand"
 
         self.harness.charm.on.install.emit()
 
-        assert self.harness.model.unit.status == MaintenanceStatus()
-    """
-    def test_when_install_then_external_service_is_created(self):
-        self.mock_charm_client = TestCharm.patcher_charm_client.start()
+        self.assertEqual(self.harness.model.unit.status, MaintenanceStatus())
+
+    @patch("charm.Client")
+    def test_when_install_then_external_service_is_created(self, patch_client):
         self.harness.charm.on.install.emit()
 
         expected_service = Service(
             apiVersion="v1",
             kind="Service",
             metadata=ObjectMeta(
-                namespace=NAMESPACE,
+                namespace=self.namespace,
                 name=f"{self.harness.charm.app.name}-external",
                 labels={
                     "app.kubernetes.io/name": self.harness.charm.app.name,
@@ -1651,47 +1770,51 @@ class TestCharm:
             ),
         )
 
-        self.mock_charm_client.return_value.apply.assert_called_once_with(
+        patch_client.return_value.apply.assert_called_once_with(
             expected_service, field_manager="sdcore-upf-k8s"
         )
-    """
 
-    def test_given_service_exists_on_remove_then_external_service_is_deleted(self):
-        self.mock_charm_client = TestCharm.patcher_charm_client.start()
+    @patch("charm.Client")
+    def test_given_service_exists_on_remove_then_external_service_is_deleted(self, patch_client):
         self.harness.charm.on.remove.emit()
 
-        self.mock_charm_client.return_value.delete.assert_called_once_with(
+        patch_client.return_value.delete.assert_called_once_with(
             Service,
             name=f"{self.harness.charm.app.name}-external",
-            namespace=NAMESPACE,
+            namespace=self.namespace,
         )
 
+    @patch("charm.Client")
     def test_given_service_does_not_exist_on_remove_then_no_exception_is_thrown(
-        self,
+        self, patch_client
     ):
-        self.mock_charm_client = TestCharm.patcher_charm_client.start()
-        self.mock_charm_client.return_value.delete.side_effect = HTTPStatusError(
+        patch_client.return_value.delete.side_effect = HTTPStatusError(
             message='services "upf-external" not found',
             request=None,
             response=None,
         )
         self.harness.charm.on.remove.emit()
 
-        self.mock_charm_client.return_value.delete.assert_called_once_with(
+        patch_client.return_value.delete.assert_called_once_with(
             Service,
             name=f"{self.harness.charm.app.name}-external",
-            namespace=NAMESPACE,
+            namespace=self.namespace,
         )
 
+    @patch("lightkube.core.client.Client.create")
+    @patch("ops.model.Container.get_service")
+    @patch(
+        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
+        Mock(return_value=True),
+    )
+    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
+    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_default_config_when_create_network_attachment_definitions_then_interface_mtu_not_set_in_the_network_attachment_definitions(  # noqa: E501
-        self,
+        self, patch_get_service, kubernetes_create_object
     ):
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
-        self.mock_dpdk_is_configured.return_value = True
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
+        patch_get_service.return_value = service_info_mock
         self.harness.update_config(
             key_values={
                 "access-ip": "192.168.252.3/24",
@@ -1702,22 +1825,29 @@ class TestCharm:
             }
         )
 
-        create_nad_calls = self.mock_client_create.call_args_list
+        create_nad_calls = kubernetes_create_object.call_args_list
         for create_nad_call in create_nad_calls:
             create_nad_call_args = next(
                 iter(filter(lambda call_item: isinstance(call_item, dict), create_nad_call))
             )
             nad_config = json.loads(create_nad_call_args.get("obj").spec.get("config"))
-            assert "mtu" not in nad_config
+            self.assertNotIn("mtu", nad_config)
 
+    @patch("charm.check_output")
+    @patch("lightkube.core.client.Client.list")
+    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
+    @patch("dpdk.DPDK.is_configured")
     def test_given_cpu_supporting_required_hugepages_instructions_when_hugepages_enabled_then_charm_goes_to_waiting_status(  # noqa: E501
-        self
+        self,
+        patch_dpdk_is_configured,
+        patch_hugepages_is_patched,
+        patch_list,
+        patched_check_output,
     ):
-        self.mock_check_output = TestCharm.patcher_check_output.start()
-        self.mock_dpdk_is_configured.return_value = True
-        self.mock_is_patched.return_value = True
-        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        self.mock_client_list.side_effect = [
+        patch_dpdk_is_configured.return_value = True
+        patch_hugepages_is_patched.return_value = True
+        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        patch_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1735,15 +1865,20 @@ class TestCharm:
         )
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == WaitingStatus("Waiting for bessd container to be ready")
+        self.assertEqual(
+            self.harness.model.unit.status,
+            WaitingStatus("Waiting for bessd container to be ready"),
+        )
 
+    @patch("charm.check_output")
+    @patch("lightkube.core.client.Client.list")
+    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_cpu_supporting_required_hugepages_instructions_and_not_available_hugepages_when_hugepages_enabled_then_charm_goes_to_blocked_status(  # noqa: E501
-        self
+        self, patch_hugepages_is_patched, patch_list, patched_check_output
     ):
-        self.mock_check_output = TestCharm.patcher_check_output.start()
-        self.mock_is_patched.return_value = False
-        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        self.mock_client_list.return_value = [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "1Gi"}))]
+        patch_hugepages_is_patched.return_value = False
+        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        patch_list.return_value = [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "1Gi"}))]
 
         self.harness.update_config(
             key_values={
@@ -1755,16 +1890,26 @@ class TestCharm:
         )
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == BlockedStatus("Not enough HugePages available")
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("Not enough HugePages available"),
+        )
 
+    @patch("charm.check_output")
+    @patch("lightkube.core.client.Client.list")
+    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
+    @patch("dpdk.DPDK.is_configured")
     def test_given_hugepages_not_available_then_hugepages_available_when_update_status_then_charm_goes_to_waiting_status(  # noqa: E501
-        self
+        self,
+        patch_dpdk_is_configured,
+        patch_hugepages_is_patched,
+        patch_list,
+        patched_check_output,
     ):
-        self.mock_check_output = TestCharm.patcher_check_output.start()
-        self.mock_dpdk_is_configured.return_value = True
-        self.mock_is_patched.return_value = True
-        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        self.mock_client_list.side_effect = [
+        patch_dpdk_is_configured.return_value = True
+        patch_hugepages_is_patched.return_value = True
+        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        patch_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "1Gi"}))],
             [],
             [],
@@ -1783,22 +1928,28 @@ class TestCharm:
         )
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == BlockedStatus("Not enough HugePages available")
+        self.assertEqual(
+            self.harness.model.unit.status,
+            BlockedStatus("Not enough HugePages available"),
+        )
 
         self.harness.charm.on.update_status.emit()
         self.harness.evaluate_status()
 
-        assert self.harness.model.unit.status == WaitingStatus("Waiting for bessd container to be ready")
-"""
+        self.assertEqual(
+            self.harness.model.unit.status,
+            WaitingStatus("Waiting for bessd container to be ready"),
+        )
+
     @patch("charm.check_output")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.multus_is_available")
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_multus_disabled_then_enabled_when_update_status_then_status_is_active(
-        self, self.mock_is_patched, patch_multus_available, self.mock_check_output
+        self, patch_hugepages_is_patched, patch_multus_available, patched_check_output
     ):
-        self.mock_is_patched.return_value = True
+        patch_hugepages_is_patched.return_value = True
         patch_multus_available.side_effect = [False, False, False, True]
-        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
         self.harness.charm.on.update_status.emit()
         self.harness.evaluate_status()
         self.assertEqual(
@@ -1815,9 +1966,9 @@ class TestCharm:
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_no_interface_mtu_specified_in_nad(  # noqa: E501
         self,
-        self.mock_is_patched,
+        patch_hugepages_is_patched,
     ):
-        self.mock_is_patched.return_value = True
+        patch_hugepages_is_patched.return_value = True
         self.harness.update_config(
             key_values={
                 "access-ip": "192.168.252.3/24",
@@ -1841,11 +1992,11 @@ class TestCharm:
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
     @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_default_config_with_interfaces_mtu_sizes_when_create_network_attachment_definitions_then_interface_mtu_set_in_the_network_attachment_definitions(  # noqa: E501
-        self, self.mock_get_service, self.mock_client_create
+        self, patch_get_service, kubernetes_create_object
     ):
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        self.mock_get_service.return_value = service_info_mock
+        patch_get_service.return_value = service_info_mock
         self.harness.update_config(
             key_values={
                 "access-ip": "192.168.252.3/24",
@@ -1858,7 +2009,7 @@ class TestCharm:
             }
         )
 
-        create_nad_calls = self.mock_client_create.call_args_list
+        create_nad_calls = kubernetes_create_object.call_args_list
         for create_nad_call in create_nad_calls:
             create_nad_call_args = next(
                 iter(filter(lambda call_item: isinstance(call_item, dict), create_nad_call))
@@ -1891,22 +2042,22 @@ class TestCharm:
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_container_can_connect_bessd_pebble_ready_when_core_net_mtu_config_changed_to_a_different_valid_value_then_delete_pod_is_called(  # noqa: E501
         self,
-        self.mock_is_patched,
-        self.mock_delete_pod,
-        self.mock_multus_is_ready,
-        self.mock_list_na_definitions,
+        patch_hugepages_is_patched,
+        patch_delete_pod,
+        patch_multus_is_ready,
+        patch_list_na_definitions,
         _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
+        patch_hugepages_is_patched.return_value = True
+        patch_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
         update_nad_labels(original_nads, self.harness.charm.app.name)
-        self.mock_list_na_definitions.return_value = original_nads
+        patch_list_na_definitions.return_value = original_nads
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_1})
-        self.mock_delete_pod.assert_called_once()
+        patch_delete_pod.assert_called_once()
 
     @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
@@ -1916,26 +2067,26 @@ class TestCharm:
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_container_can_connect_bessd_pebble_ready_when_core_net_mtu_config_changed_to_different_valid_values_then_delete_pod_called_twice(  # noqa: E501
         self,
-        self.mock_is_patched,
-        self.mock_delete_pod,
-        self.mock_multus_is_ready,
-        self.mock_list_na_definitions,
+        patch_hugepages_is_patched,
+        patch_delete_pod,
+        patch_multus_is_ready,
+        patch_list_na_definitions,
         _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
+        patch_hugepages_is_patched.return_value = True
+        patch_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
         update_nad_labels(original_nads, self.harness.charm.app.name)
-        self.mock_list_na_definitions.return_value = original_nads
+        patch_list_na_definitions.return_value = original_nads
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_1})
         modified_nads = self.harness.charm._network_attachment_definitions_from_config()
         update_nad_labels(modified_nads, self.harness.charm.app.name)
-        self.mock_list_na_definitions.return_value = modified_nads
+        patch_list_na_definitions.return_value = modified_nads
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})
-        self.assertEqual(self.mock_delete_pod.call_count, 2)
+        self.assertEqual(patch_delete_pod.call_count, 2)
 
     @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
@@ -1945,39 +2096,39 @@ class TestCharm:
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_container_can_connect_bessd_pebble_ready_when_core_net_mtu_config_changed_to_same_valid_value_multiple_times_then_delete_pod_called_once(  # noqa: E501
         self,
-        self.mock_is_patched,
-        self.mock_delete_pod,
-        self.mock_multus_is_ready,
-        self.mock_list_na_definitions,
+        patch_hugepages_is_patched,
+        patch_delete_pod,
+        patch_multus_is_ready,
+        patch_list_na_definitions,
         _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        \"""Delete pod is called for the first config change, setting the same config value does not trigger pod restarts.\"""  # noqa: E501, W505
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
+        """Delete pod is called for the first config change, setting the same config value does not trigger pod restarts."""  # noqa: E501, W505
+        patch_hugepages_is_patched.return_value = True
+        patch_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
         update_nad_labels(original_nads, self.harness.charm.app.name)
-        self.mock_list_na_definitions.return_value = original_nads
+        patch_list_na_definitions.return_value = original_nads
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})
-        self.mock_delete_pod.assert_called_once()
+        patch_delete_pod.assert_called_once()
         nads_after_first_config_change = (
             self.harness.charm._network_attachment_definitions_from_config()
         )
         update_nad_labels(nads_after_first_config_change, self.harness.charm.app.name)
-        self.mock_list_na_definitions.return_value = nads_after_first_config_change
+        patch_list_na_definitions.return_value = nads_after_first_config_change
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})
-        self.mock_delete_pod.assert_called_once()
+        patch_delete_pod.assert_called_once()
         nads_after_second_config_change = (
             self.harness.charm._network_attachment_definitions_from_config()
         )
         update_nad_labels(nads_after_second_config_change, self.harness.charm.app.name)
         for nad in nads_after_second_config_change:
             nad.metadata.labels = {"app.juju.is/created-by": self.harness.charm.app.name}
-        self.mock_list_na_definitions.return_value = nads_after_second_config_change
+        patch_list_na_definitions.return_value = nads_after_second_config_change
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})
-        self.mock_delete_pod.assert_called_once()
+        patch_delete_pod.assert_called_once()
 
     @patch("ops.model.Container.get_service")
     @patch("charm.UPFOperatorCharm.delete_pod")
@@ -1985,16 +2136,15 @@ class TestCharm:
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_hardware_checksum_is_enabled_when_value_changes_then_delete_pod_is_called_once(  # noqa: E501
         self,
-        self.mock_is_patched,
-        self.mock_multus_is_ready,
-        self.mock_delete_pod,
+        patch_hugepages_is_patched,
+        patch_multus_is_ready,
+        patch_delete_pod,
         _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        self.mock_is_patched.return_value = True
-        self.mock_multus_is_ready.return_value = True
+        patch_hugepages_is_patched.return_value = True
+        patch_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         self.harness.update_config(key_values={"enable-hw-checksum": False})
-        self.mock_delete_pod.assert_called_once()
-"""
+        patch_delete_pod.assert_called_once()

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,7 +2,7 @@
 # See LICENSE file for licensing details.
 
 import json
-import unittest
+import pytest
 from unittest.mock import Mock, call, patch
 
 from charm import (
@@ -45,17 +45,11 @@ VALID_ACCESS_MAC = "00-b0-d0-63-c2-26"
 INVALID_ACCESS_MAC = "something"
 VALID_CORE_MAC = "00-b0-d0-63-c2-36"
 INVALID_CORE_MAC = "wrong"
+NAMESPACE = "whatever"
 
 
 def read_file(path: str) -> str:
-    """Read a file and returns as a string.
-
-    Args:
-        path (str): path to the file.
-
-    Returns:
-        str: content of the file.
-    """
+    """Read a file and return its content as a string."""
     with open(path, "r") as f:
         content = f.read()
     return content
@@ -72,28 +66,52 @@ def update_nad_labels(nads: list[NetworkAttachmentDefinition], app_name: str) ->
         nad.metadata.labels = {"app.juju.is/created-by": app_name}
 
 
-class TestCharmInitialisation(unittest.TestCase):
-
-    def setUp(self):
-        self.patch_k8s_client = patch("lightkube.core.client.GenericSyncClient")
-        self.patch_k8s_client.start()
-        self.namespace = "whatever"
-        self.harness = testing.Harness(UPFOperatorCharm)
-        self.harness.set_model_name(name=self.namespace)
-        self.harness.set_leader(is_leader=True)
-
-        self.maxDiff = None
-        self.root = self.harness.get_filesystem_root("bessd")
-        (self.root / "etc/bess/conf").mkdir(parents=True)
-        self.addCleanup(self.harness.cleanup)
-
-    @patch(
+class TestCharmInitialisation:
+    
+    patcher_k8s_client = patch("lightkube.core.client.GenericSyncClient")
+    patcher_client_list = patch("lightkube.core.client.Client.list")
+    patcher_check_output = patch("charm.check_output")
+    patcher_delete_pod = patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.delete_pod")
+    patcher_is_patched = patch(
         f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
         Mock(return_value=True),
     )
-    @patch("lightkube.core.client.Client.list")
-    def test_given_bad_config_when_config_changed_then_status_is_blocked(self, patched_list):
-        patched_list.side_effect = [
+    patcher_multus_is_ready = patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
+    patcher_list_na_definitions = patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
+    patcher_get_service = patch("ops.model.Container.get_service")
+    
+    @pytest.fixture()
+    def setUp(self):
+        TestCharmInitialisation.patcher_k8s_client.start()
+        self.mock_client_list = TestCharmInitialisation.patcher_client_list.start()
+        self.mock_is_patched = TestCharmInitialisation.patcher_is_patched.start()
+        self.mock_check_output = TestCharmInitialisation.patcher_check_output.start()
+        self.mock_delete_pod = TestCharmInitialisation.patcher_delete_pod.start()
+        self.mock_multus_is_ready = TestCharmInitialisation.patcher_multus_is_ready.start()
+        self.mock_list_na_definitions = TestCharmInitialisation.patcher_list_na_definitions.start()
+        self.mock_get_service = TestCharmInitialisation.patcher_get_service.start()
+        
+    @staticmethod
+    def tearDown() -> None:
+        patch.stopall()
+        
+    def add_storage(self) -> None:
+        self.root = self.harness.get_filesystem_root("bessd")
+        (self.root / "etc/bess/conf").mkdir(parents=True)
+        
+    @pytest.fixture(autouse=True)
+    def harness(self, setUp, request):
+        self.harness = testing.Harness(UPFOperatorCharm)
+        self.harness.set_model_name(name=NAMESPACE)
+        self.harness.set_leader(is_leader=True)
+        #self.harness.begin()
+        self.add_storage()
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.tearDown)
+
+    def test_given_bad_config_when_config_changed_then_status_is_blocked(self):
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
@@ -101,19 +119,11 @@ class TestCharmInitialisation(unittest.TestCase):
         self.harness.update_config(key_values={"dnn": ""})
         self.harness.begin()
         self.harness.evaluate_status()
+        
+        assert self.harness.model.unit.status == BlockedStatus("The following configurations are not valid: ['dnn']")
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("The following configurations are not valid: ['dnn']"),
-        )
-
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch("lightkube.core.client.Client.list")
-    def test_given_empty_upf_mode_when_config_changed_then_status_is_blocked(self, patched_list):
-        patched_list.side_effect = [
+    def test_given_empty_upf_mode_when_config_changed_then_status_is_blocked(self):
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
@@ -122,20 +132,12 @@ class TestCharmInitialisation(unittest.TestCase):
         self.harness.begin()
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("The following configurations are not valid: ['upf-mode']"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("The following configurations are not valid: ['upf-mode']")
 
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch("lightkube.core.client.Client.list")
     def test_given_unsupported_upf_mode_when_config_changed_then_status_is_blocked(
-        self, patched_list
+        self
     ):
-        patched_list.side_effect = [
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
@@ -144,22 +146,13 @@ class TestCharmInitialisation(unittest.TestCase):
         self.harness.begin()
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("The following configurations are not valid: ['upf-mode']"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("The following configurations are not valid: ['upf-mode']")
 
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch("charm.check_output")
-    @patch("lightkube.core.client.Client.list")
     def test_given_upf_mode_set_to_dpdk_but_other_required_configs_not_set_when_config_changed_then_status_is_blocked(  # noqa: E501
-        self, patched_list, patched_check_output
+        self
     ):
-        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        patched_list.side_effect = [
+        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
@@ -168,24 +161,15 @@ class TestCharmInitialisation(unittest.TestCase):
         self.harness.begin()
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus(
+        assert self.harness.model.unit.status == BlockedStatus(
                 "The following configurations are not valid: ['access-interface-mac-address', 'core-interface-mac-address']"  # noqa: E501, W505
-            ),
-        )
+            )
 
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch("charm.check_output")
-    @patch("lightkube.core.client.Client.list")
     def test_given_upf_mode_set_to_dpdk_and_hugepages_enabled_but_mac_addresses_of_access_and_core_interfaces_not_set_when_config_changed_then_status_is_blocked(  # noqa: E501
-        self, patched_list, patched_check_output
+        self
     ):
-        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        patched_list.side_effect = [
+        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
@@ -194,24 +178,15 @@ class TestCharmInitialisation(unittest.TestCase):
         self.harness.begin()
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus(
+        assert self.harness.model.unit.status == BlockedStatus(
                 "The following configurations are not valid: ['access-interface-mac-address', 'core-interface-mac-address']"  # noqa: E501, W505
-            ),
-        )
+            )
 
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch("charm.check_output")
-    @patch("lightkube.core.client.Client.list")
     def test_given_upf_mode_set_to_dpdk_and_hugepages_enabled_but_access_interface_mac_addresses_is_invalid_when_config_changed_then_status_is_blocked(  # noqa: E501
-        self, patched_list, patched_check_output
+        self
     ):
-        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        patched_list.side_effect = [
+        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
@@ -227,24 +202,15 @@ class TestCharmInitialisation(unittest.TestCase):
         self.harness.begin()
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus(
+        assert self.harness.model.unit.status == BlockedStatus(
                 "The following configurations are not valid: ['access-interface-mac-address']"
-            ),
-        )
+            )
 
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch("charm.check_output")
-    @patch("lightkube.core.client.Client.list")
     def test_given_upf_mode_set_to_dpdk_and_hugepages_enabled_but_core_interface_mac_addresses_is_invalid_when_config_changed_then_status_is_blocked(  # noqa: E501
-        self, patched_list, patched_check_output
+        self
     ):
-        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        patched_list.side_effect = [
+        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
@@ -260,22 +226,16 @@ class TestCharmInitialisation(unittest.TestCase):
         self.harness.begin()
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus(
+        assert self.harness.model.unit.status == BlockedStatus(
                 "The following configurations are not valid: ['core-interface-mac-address']"
-            ),
-        )
+            )
 
-    @patch("charm.check_output")
-    @patch("charm.Client", new=Mock)
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
+    #@patch("charm.Client", new=Mock)
     def test_given_cpu_not_supporting_required_hugepages_instructions_when_hugepages_enabled_then_charm_goes_to_blocked_status(  # noqa: E501
-        self, patch_hugepages_is_patched, patched_check_output
+        self
     ):
-        patch_hugepages_is_patched.return_value = False
-        patched_check_output.return_value = b"Flags: ssse3 fma cx16 rdrand"
-
+        self.mock_is_patched.return_value = False
+        self.mock_check_output.return_value = b"Flags: ssse3 fma cx16 rdrand"
         self.harness.update_config(
             key_values={
                 "cni-type": "vfioveth",
@@ -287,17 +247,10 @@ class TestCharmInitialisation(unittest.TestCase):
         self.harness.begin()
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("CPU is not compatible, see logs for more details"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("CPU is not compatible, see logs for more details")
 
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
     def test_given_default_config_with_interfaces_zero_mtu_sizes_when_network_attachment_definitions_from_config_is_called_then_status_is_blocked(  # noqa: E501
-        self,
+        self
     ):
         self.harness.update_config(
             key_values={
@@ -308,50 +261,30 @@ class TestCharmInitialisation(unittest.TestCase):
         self.harness.begin()
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus(
+        assert self.harness.model.unit.status == BlockedStatus(
                 "The following configurations are not valid: ['access-interface-mtu-size', 'core-interface-mtu-size']"  # noqa: E501, W505
-            ),
         )
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.delete_pod")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
+    #@patch("ops.model.Container.get_service")
+    #@patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
     def test_given_container_can_connect_bessd_pebble_ready_when_core_net_mtu_config_changed_to_an_invalid_value_then_delete_pod_is_not_called(  # noqa: E501
-        self,
-        patch_delete_pod,
-        patch_multus_is_ready,
-        patch_list_na_definitions,
-        _,
+        self
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        patch_multus_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         self.harness.begin()
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
         update_nad_labels(original_nads, self.harness.charm.app.name)
-        patch_list_na_definitions.return_value = original_nads
+        self.mock_list_na_definitions.return_value = original_nads
         self.harness.update_config(key_values={"core-interface-mtu-size": TOO_BIG_MTU_SIZE})
-        patch_delete_pod.assert_not_called()
-
-    @patch("ops.model.Container.get_service")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
+        self.mock_delete_pod.assert_not_called()
+    """
+    #@patch("ops.model.Container.get_service")
+    #@patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_hardware_checksum_is_enabled_when_bessd_pebble_ready_then_config_file_has_hwcksum_enabled(  # noqa: E501
         self,
-        _,
-        __,
     ):
         self.harness.handle_exec("bessd", [], result=0)
         self.harness.set_can_connect("bessd", True)
@@ -361,9 +294,9 @@ class TestCharmInitialisation(unittest.TestCase):
         self.harness.container_pebble_ready(container_name="bessd")
 
         config = json.loads((self.root / "etc/bess/conf/upf.json").read_text())
-        self.assertIn("hwcksum", config)
-        self.assertFalse(config["hwcksum"])
-
+        assert "hwcksum" in config
+        assert config["hwcksum"] is False
+    """
     def test_given_default_config_with_interfaces_when_network_attachment_definitions_from_config_is_called_then_interfaces_specified_in_nad(  # noqa: E501
         self,
     ):
@@ -384,32 +317,62 @@ class TestCharmInitialisation(unittest.TestCase):
         nads = self.harness.charm._network_attachment_definitions_from_config()
         for nad in nads:
             config = json.loads(nad.spec["config"])
-            self.assertTrue(ACCESS_INTERFACE_NAME or CORE_INTERFACE_NAME in config["master"])
-            self.assertEqual(config["type"], "macvlan")
+            assert (ACCESS_INTERFACE_NAME or CORE_INTERFACE_NAME in config["master"])
+            assert config["type"] == "macvlan"
 
 
-class TestCharm(unittest.TestCase):
-
+class TestCharm:
+    
+    patcher_k8s_client = patch("lightkube.core.client.GenericSyncClient")
+    patcher_get_service = patch("ops.model.Container.get_service")
+    patcher_multus_is_ready = patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
+    patcher_is_patched = patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
+    patcher_publish_upf_information = patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
+    patcher_publish_upf_n4_information = patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
+    patcher_pfcp_port = patch("charm.PFCP_PORT", TEST_PFCP_PORT)
+    patcher_lightkube_client_get = patch("lightkube.core.client.Client.get")
+    patcher_client_list = patch("lightkube.core.client.Client.list")
+    patcher_client_create = patch("lightkube.core.client.Client.create")
+    patcher_dpdk_is_configured = patch("charm.DPDK.is_configured")
+    patcher_k8s_statefulset_patch = patch("lightkube.core.client.Client.patch")
+    patcher_check_output = patch("charm.check_output")
+    patcher_charm_client = patch("charm.Client")
+    @pytest.fixture()
     def setUp(self):
-        self.patch_k8s_client = patch("lightkube.core.client.GenericSyncClient")
-        self.patch_k8s_client.start()
-        self.namespace = "whatever"
-        self.harness = testing.Harness(UPFOperatorCharm)
-        self.harness.set_model_name(name=self.namespace)
-        self.harness.set_leader(is_leader=True)
-
-        self.maxDiff = None
+        self.mock_k8s_client = TestCharm.patcher_k8s_client.start()
+        self.mock_get_service = TestCharm.patcher_get_service.start()
+        self.mock_multus_is_ready = TestCharm.patcher_multus_is_ready.start()
+        self.mock_is_patched = TestCharm.patcher_is_patched.start()
+        self.mock_publish_upf_information = TestCharm.patcher_publish_upf_information.start()
+        self.mock_publish_upf_n4_information = TestCharm.patcher_publish_upf_n4_information.start()
+        self.mock_pfcp_port = TestCharm.patcher_pfcp_port.start()
+        self.mock_lightkube_client_get = TestCharm.patcher_lightkube_client_get.start()
+        self.mock_client_list = TestCharm.patcher_client_list.start()
+        self.mock_client_create = TestCharm.patcher_client_create.start()
+        self.mock_dpdk_is_configured = TestCharm.patcher_dpdk_is_configured.start()
+        self.mock_k8s_statefulset_patch = TestCharm.patcher_k8s_statefulset_patch.start()
+        
+    def add_storage(self) -> None:
         self.root = self.harness.get_filesystem_root("bessd")
         (self.root / "etc/bess/conf").mkdir(parents=True)
-        self.addCleanup(self.harness.cleanup)
+        
+    @staticmethod
+    def tearDown() -> None:
+        patch.stopall()
+        
+    @pytest.fixture(autouse=True)
+    def harness(self, setUp, request):
+        self.harness = testing.Harness(UPFOperatorCharm)
+        self.harness.set_model_name(name=NAMESPACE)
+        self.harness.set_leader(is_leader=True)
+        self.add_storage()
         self.harness.begin()
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.tearDown)
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bessd_config_file_not_yet_written_when_bessd_pebble_ready_then_config_file_is_written(  # noqa: E501
-        self,
-        _,
-        __,
+        self
     ):
         self.harness.handle_exec("bessd", [], result=0)
         self.harness.set_can_connect("bessd", True)
@@ -417,14 +380,10 @@ class TestCharm(unittest.TestCase):
         self.harness.container_pebble_ready(container_name="bessd")
         expected_config_file_content = read_file("tests/unit/expected_upf.json").strip()
 
-        self.assertEqual(
-            (self.root / "etc/bess/conf/upf.json").read_text(), expected_config_file_content
-        )
+        assert (self.root / "etc/bess/conf/upf.json").read_text() == expected_config_file_content
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bessd_config_file_not_yet_written_when_config_storage_attached_then_config_file_is_written(  # noqa: E501
-        self, _, __
+        self
     ):
         self.harness.handle_exec("bessd", [], result=0)
         self.harness.set_can_connect("bessd", True)
@@ -435,30 +394,22 @@ class TestCharm(unittest.TestCase):
 
         expected_config_file_content = read_file("tests/unit/expected_upf.json").strip()
 
-        self.assertEqual(
-            (self.root / "etc/bess/conf/upf.json").read_text(), expected_config_file_content
-        )
+        assert (self.root / "etc/bess/conf/upf.json").read_text() == expected_config_file_content
 
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bessd_config_file_matches_when_bessd_pebble_ready_then_config_file_is_not_changed(  # noqa: E501
-        self,
-        patch_is_ready,
+        self
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
         expected_upf_content = read_file("tests/unit/expected_upf.json").strip()
         (self.root / "etc/bess/conf/upf.json").write_text(expected_upf_content)
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        self.assertEqual((self.root / "etc/bess/conf/upf.json").read_text(), expected_upf_content)
+        assert (self.root / "etc/bess/conf/upf.json").read_text() == expected_upf_content
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bess_configured_when_bessd_pebble_ready_then_expected_pebble_plan_is_applied(  # noqa: E501
-        self,
-        patch_is_ready,
-        _,
+        self
     ):
         grpc_check_cmd = "/opt/bess/bessctl/bessctl show version".split()
         accessRoutes_check_cmd = "/opt/bess/bessctl/bessctl show module accessRoutes".split()  # noqa: N806
@@ -475,7 +426,7 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", bessctl_cmd, result=0)
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
         expected_plan = {
@@ -510,14 +461,10 @@ class TestCharm(unittest.TestCase):
 
         updated_plan = self.harness.get_container_pebble_plan("bessd").to_dict()
 
-        self.assertEqual(expected_plan, updated_plan)
+        assert expected_plan == updated_plan
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bess_not_configured_when_bessd_pebble_ready_then_routectl_service_not_started(  # noqa: E501
-        self,
-        patch_is_ready,
-        _,
+        self
     ):
         grpc_check_cmd = "/opt/bess/bessctl/bessctl show version".split()
         accessRoutes_check_cmd = "/opt/bess/bessctl/bessctl show module accessRoutes".split()  # noqa: N806
@@ -534,16 +481,14 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", bessctl_cmd, result=0)
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        self.assertNotIn("routectl", self.harness.get_container_pebble_plan("bessd").services)
+        assert "routectl" not in self.harness.get_container_pebble_plan("bessd").services
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_can_connect_to_bessd_when_bessd_pebble_ready_then_ip_route_is_created(
-        self, patch_is_ready, _
+        self
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
@@ -578,18 +523,16 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", ["iptables-legacy"], result=0)
         self.harness.handle_exec("bessd", ["/opt/bess/bessctl/bessctl"], result=0)
         self.harness.handle_exec("bessd", ip_route_show_cmd, result="")
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        self.assertTrue(ip_route_replace_called)
-        self.assertEqual(timeout, 30)
-        self.assertEqual(environment, {})
+        assert ip_route_replace_called
+        assert timeout == 30
+        assert environment == {}
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_can_connect_to_bessd_when_bessd_pebble_ready_then_gnb_subnet_route_is_created(
-        self, patch_is_ready, _
+        self
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
@@ -624,18 +567,16 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", ["iptables-legacy"], result=0)
         self.harness.handle_exec("bessd", ["/opt/bess/bessctl/bessctl"], result=0)
         self.harness.handle_exec("bessd", ip_route_show_cmd, result="")
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        self.assertTrue(gnb_subnet_route_replace_called)
-        self.assertEqual(timeout, 30)
-        self.assertEqual(environment, {})
+        assert gnb_subnet_route_replace_called
+        assert timeout == 30
+        assert environment == {}
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_iptables_rule_is_not_yet_created_when_bessd_pebble_ready_then_rule_is_created(
-        self, patch_is_ready, _
+        self
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
@@ -679,17 +620,16 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", iptables_check_cmd, result=1)
         self.harness.handle_exec("bessd", iptables_drop_cmd, handler=iptables_handler)
         self.harness.handle_exec("bessd", ["/opt/bess/bessctl/bessctl"], result=0)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
-        self.assertTrue(iptables_drop_called)
-        self.assertEqual(timeout, 30)
-        self.assertEqual(environment, {})
+        
+        assert iptables_drop_called
+        assert timeout == 30
+        assert environment == {}
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_iptables_rule_is_created_when_bessd_pebble_ready_then_rule_is_not_re_created(
-        self, patch_is_ready, _
+        self
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
@@ -716,12 +656,12 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", iptables_drop_cmd, handler=iptables_handler)
         self.harness.handle_exec("bessd", ["iptables-legacy"], result=0)
         self.harness.handle_exec("bessd", ["/opt/bess/bessctl/bessctl"], result=0)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        self.assertFalse(iptables_drop_called)
-
+        assert not iptables_drop_called
+    """
     @parameterized.expand(
         [
             [1, 0, "RUNNING"],
@@ -732,7 +672,7 @@ class TestCharm(unittest.TestCase):
     @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_can_connect_to_bessd_when_bessd_pebble_ready_then_bessctl_configure_is_executed(
-        self, accessRoutes_check_out, coreRoutes_check_out, config_check_out, patch_is_ready, _  # noqa: N803
+        self, accessRoutes_check_out, coreRoutes_check_out, config_check_out, self.mock_multus_is_ready, _  # noqa: N803
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
@@ -762,7 +702,7 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", coreRoutes_check_cmd, result=coreRoutes_check_out)
         self.harness.handle_exec("bessd", config_check_cmd, result=config_check_out)
         self.harness.handle_exec("bessd", bessctl_cmd, handler=bessctl_handler)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
@@ -771,11 +711,10 @@ class TestCharm(unittest.TestCase):
         self.assertEqual(
             environment, {"CONF_FILE": "/etc/bess/conf/upf.json", "PYTHONPATH": "/opt/bess"}
         )
+    """
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_connects_and_bess_configured_then_bessctl_configure_not_executed(
-        self, patch_is_ready, _
+        self
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
@@ -800,54 +739,40 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", coreRoutes_check_cmd, result=0)
         self.harness.handle_exec("bessd", config_check_cmd, result="RUNNING")
         self.harness.handle_exec("bessd", bessctl_cmd, handler=bessctl_handler)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        self.assertFalse(bessctl_called)
+        assert not bessctl_called
 
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_storage_not_attached_when_bessd_pebble_ready_then_status_is_waiting(
-        self,
-        patch_is_ready,
+        self
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
         ip_route_show_result = f"{GNB_SUBNET} via {ACCESS_GW_IP}\ndefault via {CORE_GW_IP}"
 
         self.harness.handle_exec("bessd", ip_route_show_cmd, result=ip_route_show_result)
         self.harness.handle_exec("bessd", [], result=0)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
         (self.root / "etc/bess/conf").rmdir()
 
         self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for storage to be attached"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for storage to be attached")
 
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_multus_not_configured_when_bessd_pebble_ready_then_status_is_waiting(
         self,
-        patch_is_ready,
     ):
-        patch_is_ready.return_value = False
+        self.mock_multus_is_ready.return_value = False
 
         self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for Multus to be ready"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for Multus to be ready")
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_config_file_is_written_and_all_services_are_running_when_bessd_pebble_ready_then_status_is_active(  # noqa: E501
         self,
-        patch_is_ready,
-        patch_get_service,
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
         ip_route_show_result = f"{GNB_SUBNET} via {ACCESS_GW_IP}\ndefault via {CORE_GW_IP}"
@@ -856,26 +781,22 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", [], result="RUNNING")
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patch_is_ready.return_value = True
+        self.mock_get_service.return_value = service_info_mock
+        self.mock_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="pfcp-agent", val=True)
 
         self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
+        assert self.harness.model.unit.status == ActiveStatus()
 
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    @patch("ops.model.Container.get_service")
     def test_given_bessd_service_is_running_when_pfcp_agent_pebble_ready_then_pebble_plan_is_applied(  # noqa: E501
-        self,
-        patch_get_service,
-        patch_multus_is_ready,
+        self
     ):
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patch_multus_is_ready.return_value = True
+        self.mock_get_service.return_value = service_info_mock
+        self.mock_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         grpc_check_cmd = "/opt/bess/bessctl/bessctl show version".split()
         accessRoutes_check_cmd = "/opt/bess/bessctl/bessctl show module accessRoutes".split()  # noqa: N806
@@ -892,7 +813,7 @@ class TestCharm(unittest.TestCase):
 
         self.harness.container_pebble_ready(container_name="pfcp-agent")
         self.harness.evaluate_status()
-        self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
+        assert self.harness.charm.unit.status == ActiveStatus()
 
         expected_plan = {
             "services": {
@@ -906,99 +827,81 @@ class TestCharm(unittest.TestCase):
 
         updated_plan = self.harness.get_container_pebble_plan("pfcp-agent").to_dict()
 
-        self.assertEqual(expected_plan, updated_plan)
+        assert expected_plan == updated_plan
 
     def test_given_cant_connect_to_bessd_container_when_pfcp_agent_pebble_ready_then_status_is_waiting(  # noqa: E501
-        self,
+        self
     ):
         self.harness.set_can_connect(container="bessd", val=False)
 
         self.harness.container_pebble_ready(container_name="pfcp-agent")
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for bessd container to be ready"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for bessd container to be ready")
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_pebble_connection_error_when_bessd_pebble_ready_then_status_is_waiting(  # noqa: E501
-        self, patch_is_ready, patch_get_service
+        self
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
         ip_route_show_result = f"{GNB_SUBNET} via {ACCESS_GW_IP}\ndefault via {CORE_GW_IP}"
 
         self.harness.handle_exec("bessd", ip_route_show_cmd, result=ip_route_show_result)
         self.harness.handle_exec("bessd", [], result=0)
-        patch_get_service.side_effect = ConnectionError()
-        patch_is_ready.return_value = True
+        self.mock_get_service.side_effect = ConnectionError()
+        self.mock_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
 
         self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for bessd service to run")
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for bessd service to run")
 
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_default_route_not_created_when_bessd_pebble_ready_then_status_is_waiting(
-        self, patch_is_ready
+        self
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
 
         self.harness.handle_exec("bessd", ip_route_show_cmd, result="")
         self.harness.handle_exec("bessd", [], result=0)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
 
         self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for default route creation")
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for default route creation")
 
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_ran_route_not_created_when_bessd_pebble_ready_then_status_is_waiting(
-        self, patch_is_ready
+        self,
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
 
         self.harness.handle_exec("bessd", ip_route_show_cmd, result=f"default via {CORE_GW_IP}")
         self.harness.handle_exec("bessd", [], result=0)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
 
         self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for RAN route creation")
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for RAN route creation")
 
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
     def test_given_fiveg_n3_relation_created_when_fiveg_n3_request_then_upf_ip_address_is_published(  # noqa: E501
-        self,
-        patched_publish_upf_information,
-        patch_hugepages_is_patched,
+        self
     ):
-        patch_hugepages_is_patched.return_value = True
+        self.mock_is_patched.return_value = True
         test_upf_access_ip_cidr = "1.2.3.4/21"
         self.harness.update_config(key_values={"access-ip": test_upf_access_ip_cidr})
 
         n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
         self.harness.add_relation_unit(n3_relation_id, "n3_requirer_app/0")
 
-        patched_publish_upf_information.assert_called_once_with(
+        self.mock_publish_upf_information.assert_called_once_with(
             relation_id=n3_relation_id, upf_ip_address=test_upf_access_ip_cidr.split("/")[0]
         )
 
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
     def test_given_unit_is_not_leader_when_fiveg_n3_request_then_upf_ip_address_is_not_published(
-        self, patched_publish_upf_information
+        self
     ):
         self.harness.set_leader(is_leader=False)
         test_upf_access_ip_cidr = "1.2.3.4/21"
@@ -1007,23 +910,15 @@ class TestCharm(unittest.TestCase):
         n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
         self.harness.add_relation_unit(n3_relation_id, "n3_requirer_app/0")
 
-        patched_publish_upf_information.assert_not_called()
+        self.mock_publish_upf_information.assert_not_called()
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
+    #@patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
     def test_given_fiveg_n3_relation_exists_when_access_ip_config_changed_then_new_upf_ip_address_is_published(  # noqa: E501
-        self,
-        patch_multus_is_ready,
-        patch_hugepages_is_patched,
-        patched_publish_upf_information,
-        _,
+        self
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        patch_multus_is_ready.return_value = True
-        patch_hugepages_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_is_patched.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
@@ -1036,15 +931,13 @@ class TestCharm(unittest.TestCase):
 
         self.harness.update_config(key_values={"access-ip": test_upf_access_ip_cidr})
 
-        patched_publish_upf_information.assert_has_calls(expected_calls)
+        self.mock_publish_upf_information.assert_has_calls(expected_calls)
 
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_fiveg_n3_relation_exists_when_access_ip_config_changed_to_invalid_cidr_then_new_upf_ip_address_is_not_published(  # noqa: E501
-        self, patch_multus_is_ready, patched_publish_upf_information
+        self
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        patch_multus_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
@@ -1053,13 +946,12 @@ class TestCharm(unittest.TestCase):
 
         self.harness.update_config(key_values={"access-ip": invalid_test_upf_access_ip_cidr})
 
-        patched_publish_upf_information.assert_called_once_with(
+        self.mock_publish_upf_information.assert_called_once_with(
             relation_id=n3_relation_id, upf_ip_address="192.168.252.3"
         )
 
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
     def test_given_unit_is_not_leader_when_fiveg_n4_request_then_upf_hostname_is_not_published(
-        self, patched_publish_upf_n4_information
+        self
     ):
         self.harness.set_leader(is_leader=False)
         test_external_upf_hostname = "test-upf.external.hostname.com"
@@ -1070,17 +962,12 @@ class TestCharm(unittest.TestCase):
         n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
         self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
 
-        patched_publish_upf_n4_information.assert_not_called()
+        self.mock_publish_upf_n4_information.assert_not_called()
 
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
-    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_set_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
-        self,
-        patched_publish_upf_n4_information,
-        patch_hugepages_is_patched,
+        self
     ):
-        patch_hugepages_is_patched.return_value = True
+        self.mock_is_patched.return_value = True
         test_external_upf_hostname = "test-upf.external.hostname.com"
         self.harness.update_config(
             key_values={"external-upf-hostname": test_external_upf_hostname}
@@ -1089,17 +976,14 @@ class TestCharm(unittest.TestCase):
         n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
         self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
 
-        patched_publish_upf_n4_information.assert_called_once_with(
+        self.mock_publish_upf_n4_information.assert_called_once_with(
             relation_id=n4_relation_id,
             upf_hostname=test_external_upf_hostname,
             upf_n4_port=TEST_PFCP_PORT,
         )
 
-    @patch("lightkube.core.client.Client.get")
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
-    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_not_set_but_external_upf_service_hostname_available_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
-        self, patched_publish_upf_n4_information, patched_lightkube_client_get
+        self
     ):
         test_external_upf_service_hostname = "test-upf.external.service.hostname.com"
         service = Mock(
@@ -1109,71 +993,56 @@ class TestCharm(unittest.TestCase):
                 )
             )
         )
-        patched_lightkube_client_get.return_value = service
+        self.mock_lightkube_client_get.return_value = service
 
         n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
         self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
 
-        patched_publish_upf_n4_information.assert_called_once_with(
+        self.mock_publish_upf_n4_information.assert_called_once_with(
             relation_id=n4_relation_id,
             upf_hostname=test_external_upf_service_hostname,
             upf_n4_port=TEST_PFCP_PORT,
         )
 
-    @patch("lightkube.core.client.Client.get")
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
-    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_not_set_and_external_upf_service_hostname_not_available_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
-        self, patched_publish_upf_n4_information, patched_lightkube_client_get
+        self,
     ):
         service = Mock(status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", spec=["ip"])])))
-        patched_lightkube_client_get.return_value = service
+        self.mock_lightkube_client_get.return_value = service
 
         n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
         self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
 
-        patched_publish_upf_n4_information.assert_called_once_with(
+        self.mock_publish_upf_n4_information.assert_called_once_with(
             relation_id=n4_relation_id,
-            upf_hostname=f"{self.harness.charm.app.name}-external.{self.namespace}"
+            upf_hostname=f"{self.harness.charm.app.name}-external.{NAMESPACE}"
             ".svc.cluster.local",
             upf_n4_port=TEST_PFCP_PORT,
         )
 
-    @patch("lightkube.core.client.Client.get")
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
-    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_not_set_and_metallb_not_available_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
-        self, patched_publish_upf_n4_information, patched_lightkube_client_get
+        self
     ):
         service = Mock(status=Mock(loadBalancer=Mock(ingress=None)))
-        patched_lightkube_client_get.return_value = service
+        self.mock_lightkube_client_get.return_value = service
 
         n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
         self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
 
-        patched_publish_upf_n4_information.assert_called_once_with(
+        self.mock_publish_upf_n4_information.assert_called_once_with(
             relation_id=n4_relation_id,
-            upf_hostname=f"{self.harness.charm.app.name}-external.{self.namespace}"
+            upf_hostname=f"{self.harness.charm.app.name}-external.{NAMESPACE}"
             ".svc.cluster.local",
             upf_n4_port=TEST_PFCP_PORT,
         )
 
-    @patch("ops.model.Container.get_service")
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_fiveg_n4_relation_exists_when_external_upf_hostname_config_changed_then_new_upf_hostname_is_published(  # noqa: E501
-        self,
-        patch_multus_is_ready,
-        patch_hugepages_is_ready,
-        patched_publish_upf_n4_information,
-        _,
+        self
     ):
         self.harness.handle_exec("bessd", [], result=0)
         test_external_upf_hostname = "test-upf.external.hostname.com"
-        patch_multus_is_ready.return_value = True
-        patch_hugepages_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_is_patched.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         self.harness.update_config(key_values={"external-upf-hostname": "whatever.com"})
@@ -1194,14 +1063,12 @@ class TestCharm(unittest.TestCase):
             key_values={"external-upf-hostname": test_external_upf_hostname}
         )
 
-        patched_publish_upf_n4_information.assert_has_calls(expected_calls)
+        self.mock_publish_upf_n4_information.assert_has_calls(expected_calls)
 
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_no_interface_specified_in_nad(  # noqa: E501
         self,
-        patch_hugepages_is_patched,
     ):
-        patch_hugepages_is_patched.return_value = True
+        self.mock_is_patched.return_value = True
         self.harness.update_config(
             key_values={
                 "access-ip": DEFAULT_ACCESS_IP,
@@ -1214,28 +1081,22 @@ class TestCharm(unittest.TestCase):
         nads = self.harness.charm._network_attachment_definitions_from_config()
         for nad in nads:
             config = json.loads(nad.spec["config"])
-            self.assertNotIn("master", config)
-            self.assertEqual("bridge", config["type"])
-            self.assertIn(config["bridge"], ("core-br", "access-br"))
+            assert "master" not in config
+            assert "bridge" == config["type"]
+            assert config["bridge"] in ("core-br", "access-br")
 
-    @patch("lightkube.core.client.Client.create")
-    @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.Client.list")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_configured_to_run_in_dpdk_mode_when_create_network_attachment_definitions_then_2_nads_are_returned(  # noqa: E501
-        self, patched_list, patch_get_service, kubernetes_create_object
+        self,
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
+        self.mock_multus_is_ready.return_value = True
+        self.mock_is_patched.return_value = True
+        self.mock_dpdk_is_configured.return_value = True
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patched_list.side_effect = [
+        self.mock_get_service.return_value = service_info_mock
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1251,27 +1112,21 @@ class TestCharm(unittest.TestCase):
             }
         )
 
-        create_nad_calls = kubernetes_create_object.call_args_list
-        self.assertEqual(len(create_nad_calls), 2)
+        create_nad_calls = self.mock_client_create.call_args_list
+        assert len(create_nad_calls) == 2
 
-    @patch("lightkube.core.client.Client.create")
-    @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.Client.list")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_configured_to_run_in_dpdk_mode_when_create_network_attachment_definitions_then_nad_type_is_vfioveth(  # noqa: E501
-        self, patched_list, patch_get_service, kubernetes_create_object
+        self
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_dpdk_is_configured.return_value = True
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patched_list.side_effect = [
+        self.mock_get_service.return_value = service_info_mock
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
@@ -1286,32 +1141,26 @@ class TestCharm(unittest.TestCase):
             }
         )
 
-        create_nad_calls = kubernetes_create_object.call_args_list
+        create_nad_calls = self.mock_client_create.call_args_list
         for create_nad_call in create_nad_calls:
             create_nad_call_args = next(
                 iter(filter(lambda call_item: isinstance(call_item, dict), create_nad_call))
             )
             nad_config = json.loads(create_nad_call_args.get("obj").spec.get("config"))
-            self.assertEqual(nad_config["type"], "vfioveth")
+            assert nad_config["type"] == "vfioveth"
 
-    @patch("lightkube.core.client.Client.create")
-    @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.Client.list")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_configured_to_run_in_dpdk_mode_when_create_network_attachment_definitions_then_access_nad_has_valid_dpdk_access_resource_specified_in_annotations(  # noqa: E501
-        self, patched_list, patch_get_service, kubernetes_create_object
+        self
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_dpdk_is_configured.return_value = True
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patched_list.side_effect = [
+        self.mock_get_service.return_value = service_info_mock
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1340,37 +1189,28 @@ class TestCharm(unittest.TestCase):
                 None,
             )
 
-        create_nad_calls = kubernetes_create_object.mock_calls
+        create_nad_calls = self.mock_client_create.mock_calls
         create_access_nad_calls = [
             _get_create_access_nad_call(create_nad_call)
             for create_nad_call in create_nad_calls
             if _get_create_access_nad_call(create_nad_call)
         ]
-        self.assertEqual(len(create_access_nad_calls), 1)
+        assert len(create_access_nad_calls) == 1
         nad_annotations = create_access_nad_calls[0].get("obj").metadata.annotations
-        self.assertTrue(
-            DPDK_ACCESS_INTERFACE_RESOURCE_NAME
-            in nad_annotations["k8s.v1.cni.cncf.io/resourceName"]
-        )
+        assert DPDK_ACCESS_INTERFACE_RESOURCE_NAME in nad_annotations["k8s.v1.cni.cncf.io/resourceName"]
 
-    @patch("lightkube.core.client.Client.create")
-    @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.Client.list")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_configured_to_run_in_dpdk_mode_when_create_network_attachment_definitions_then_core_nad_has_valid_dpdk_core_resource_specified_in_annotations(  # noqa: E501
-        self, patched_list, patch_get_service, kubernetes_create_object
+        self
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_dpdk_is_configured.return_value = True
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patched_list.side_effect = [
+        self.mock_get_service.return_value = service_info_mock
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1399,37 +1239,30 @@ class TestCharm(unittest.TestCase):
                 None,
             )
 
-        create_nad_calls = kubernetes_create_object.mock_calls
+        create_nad_calls = self.mock_client_create.mock_calls
         create_core_nad_calls = [
             _get_create_core_nad_call(create_nad_call)
             for create_nad_call in create_nad_calls
             if _get_create_core_nad_call(create_nad_call)
         ]
-        self.assertEqual(len(create_core_nad_calls), 1)
+        assert len(create_core_nad_calls) == 1
         nad_annotations = create_core_nad_calls[0].get("obj").metadata.annotations
-        self.assertTrue(
-            DPDK_CORE_INTERFACE_RESOURCE_NAME in nad_annotations["k8s.v1.cni.cncf.io/resourceName"]
-        )
+        assert DPDK_CORE_INTERFACE_RESOURCE_NAME in nad_annotations["k8s.v1.cni.cncf.io/resourceName"]
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_patch_statefulset_then_2_network_annotations_are_created(  # noqa: E501
-        self, patch_get_service, kubernetes_statefulset_patch
+        self
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
+        self.mock_get_service.return_value = service_info_mock
         self.harness.update_config()
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1445,27 +1278,22 @@ class TestCharm(unittest.TestCase):
                 NetworkAnnotation.NETWORK_ANNOTATION_RESOURCE_KEY
             )
         )
-        self.assertEqual(len(network_annotations), 2)
+        assert len(network_annotations) == 2
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_generate_network_annotations_is_called_then_access_network_annotation_created(  # noqa: E501
-        self, patch_get_service, kubernetes_statefulset_patch
+        self,
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
+        self.mock_get_service.return_value = service_info_mock
         self.harness.update_config()
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1490,28 +1318,23 @@ class TestCharm(unittest.TestCase):
                 )
             )
         )
-        self.assertTrue(access_network_annotation)
-        self.assertEqual(access_network_annotation.get("interface"), ACCESS_INTERFACE_NAME)
+        assert access_network_annotation
+        assert access_network_annotation.get("interface") == ACCESS_INTERFACE_NAME
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_generate_network_annotations_is_called_then_access_network_annotation_created_without_dpdk_specific_data(  # noqa: E501
-        self, patch_get_service, kubernetes_statefulset_patch
+        self
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
+        self.mock_get_service.return_value = service_info_mock
         self.harness.update_config()
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1536,28 +1359,23 @@ class TestCharm(unittest.TestCase):
                 )
             )
         )
-        self.assertFalse(access_network_annotation.get("mac"))
-        self.assertFalse(access_network_annotation.get("ips"))
+        assert not access_network_annotation.get("mac")
+        assert not access_network_annotation.get("ips")
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_generate_network_annotations_is_called_then_core_network_annotation_created(  # noqa: E501
-        self, patch_get_service, kubernetes_statefulset_patch
+        self
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
+        self.mock_get_service.return_value = service_info_mock
         self.harness.update_config()
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1582,28 +1400,23 @@ class TestCharm(unittest.TestCase):
                 )
             )
         )
-        self.assertTrue(access_network_annotation)
-        self.assertEqual(access_network_annotation.get("interface"), CORE_INTERFACE_NAME)
+        assert access_network_annotation
+        assert access_network_annotation.get("interface") == CORE_INTERFACE_NAME
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_generate_network_annotations_is_called_then_core_network_annotation_created_without_dpdk_specific_data(  # noqa: E501
-        self, patch_get_service, kubernetes_statefulset_patch
+        self,
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
+        self.mock_get_service.return_value = service_info_mock
         self.harness.update_config()
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1628,28 +1441,22 @@ class TestCharm(unittest.TestCase):
                 )
             )
         )
-        self.assertFalse(access_network_annotation.get("mac"))
-        self.assertFalse(access_network_annotation.get("ips"))
+        assert not access_network_annotation.get("mac")
+        assert not access_network_annotation.get("ips")
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.Client.list")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_dpdk_mode_when_patch_statefulset_then_2_network_annotations_are_created(  # noqa: E501
-        self, patched_list, patch_get_service, kubernetes_statefulset_patch
+        self,
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patched_list.side_effect = [
+        self.mock_get_service.return_value = service_info_mock
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1664,7 +1471,7 @@ class TestCharm(unittest.TestCase):
                 "core-interface-mac-address": VALID_CORE_MAC,
             }
         )
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1680,27 +1487,21 @@ class TestCharm(unittest.TestCase):
                 NetworkAnnotation.NETWORK_ANNOTATION_RESOURCE_KEY
             )
         )
-        self.assertEqual(len(network_annotations), 2)
+        assert len(network_annotations) == 2
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.Client.list")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_dpdk_mode_when_generate_network_annotations_is_called_then_access_network_annotation_created(  # noqa: E501
-        self, patched_list, patch_get_service, kubernetes_statefulset_patch
+        self,
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patched_list.side_effect = [
+        self.mock_get_service.return_value = service_info_mock
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1716,7 +1517,7 @@ class TestCharm(unittest.TestCase):
                 "core-interface-mac-address": VALID_CORE_MAC,
             }
         )
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1741,30 +1542,25 @@ class TestCharm(unittest.TestCase):
                 )
             )
         )
-        self.assertTrue(access_network_annotation)
-        self.assertEqual(access_network_annotation.get("interface"), ACCESS_INTERFACE_NAME)
-        self.assertEqual(access_network_annotation.get("mac"), VALID_ACCESS_MAC)
-        self.assertEqual(access_network_annotation.get("ips"), [VALID_ACCESS_IP])
+        assert access_network_annotation
+        assert access_network_annotation.get("interface") == ACCESS_INTERFACE_NAME
+        assert access_network_annotation.get("mac") == VALID_ACCESS_MAC
+        assert access_network_annotation.get("ips") == [VALID_ACCESS_IP]
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.Client.list")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
+
     def test_given_upf_charm_configured_to_run_in_dpdk_mode_when_generate_network_annotations_is_called_then_core_network_annotation_created(  # noqa: E501
-        self, patched_list, patch_get_service, kubernetes_statefulset_patch
+        self,
     ):
         self.harness.set_can_connect("bessd", True)
         self.harness.set_can_connect("pfcp-agent", True)
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_dpdk_is_configured.return_value = True
         self.harness.handle_exec("bessd", [], result=0)
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patched_list.side_effect = [
+        self.mock_get_service.return_value = service_info_mock
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1780,7 +1576,7 @@ class TestCharm(unittest.TestCase):
                 "core-interface-mac-address": VALID_CORE_MAC,
             }
         )
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1805,45 +1601,40 @@ class TestCharm(unittest.TestCase):
                 )
             )
         )
-        self.assertTrue(access_network_annotation)
-        self.assertEqual(access_network_annotation.get("interface"), CORE_INTERFACE_NAME)
-        self.assertEqual(access_network_annotation.get("mac"), VALID_CORE_MAC)
-        self.assertEqual(access_network_annotation.get("ips"), [VALID_CORE_IP])
+        assert access_network_annotation
+        assert access_network_annotation.get("interface") == CORE_INTERFACE_NAME
+        assert access_network_annotation.get("mac") == VALID_CORE_MAC
+        assert access_network_annotation.get("ips") == [VALID_CORE_IP]
 
-    @patch("charm.check_output")
-    @patch("charm.Client", new=Mock)
     def test_given_cpu_not_supporting_required_instructions_when_install_then_charm_goes_to_blocked_status(  # noqa: E501
-        self, patched_check_output
+        self,
     ):
-        patched_check_output.return_value = b"Flags: ssse3 fma cx16 rdrand"
+        self.mock_check_output = TestCharm.patcher_check_output.start()
+        self.mock_check_output.return_value = b"Flags: ssse3 fma cx16 rdrand"
         self.harness.charm.on.install.emit()
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("CPU is not compatible, see logs for more details"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("CPU is not compatible, see logs for more details")
 
-    @patch("charm.check_output")
-    @patch("charm.Client", new=Mock)
     def test_given_cpu_supporting_required_instructions_when_install_then_charm_goes_to_maintenance_status(  # noqa: E501
-        self, patched_check_output
+        self,
     ):
-        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand"
+        self.mock_check_output = TestCharm.patcher_check_output.start()
+        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand"
 
         self.harness.charm.on.install.emit()
 
-        self.assertEqual(self.harness.model.unit.status, MaintenanceStatus())
-
-    @patch("charm.Client")
-    def test_when_install_then_external_service_is_created(self, patch_client):
+        assert self.harness.model.unit.status == MaintenanceStatus()
+    """
+    def test_when_install_then_external_service_is_created(self):
+        self.mock_charm_client = TestCharm.patcher_charm_client.start()
         self.harness.charm.on.install.emit()
 
         expected_service = Service(
             apiVersion="v1",
             kind="Service",
             metadata=ObjectMeta(
-                namespace=self.namespace,
+                namespace=NAMESPACE,
                 name=f"{self.harness.charm.app.name}-external",
                 labels={
                     "app.kubernetes.io/name": self.harness.charm.app.name,
@@ -1860,51 +1651,47 @@ class TestCharm(unittest.TestCase):
             ),
         )
 
-        patch_client.return_value.apply.assert_called_once_with(
+        self.mock_charm_client.return_value.apply.assert_called_once_with(
             expected_service, field_manager="sdcore-upf-k8s"
         )
+    """
 
-    @patch("charm.Client")
-    def test_given_service_exists_on_remove_then_external_service_is_deleted(self, patch_client):
+    def test_given_service_exists_on_remove_then_external_service_is_deleted(self):
+        self.mock_charm_client = TestCharm.patcher_charm_client.start()
         self.harness.charm.on.remove.emit()
 
-        patch_client.return_value.delete.assert_called_once_with(
+        self.mock_charm_client.return_value.delete.assert_called_once_with(
             Service,
             name=f"{self.harness.charm.app.name}-external",
-            namespace=self.namespace,
+            namespace=NAMESPACE,
         )
 
-    @patch("charm.Client")
     def test_given_service_does_not_exist_on_remove_then_no_exception_is_thrown(
-        self, patch_client
+        self,
     ):
-        patch_client.return_value.delete.side_effect = HTTPStatusError(
+        self.mock_charm_client = TestCharm.patcher_charm_client.start()
+        self.mock_charm_client.return_value.delete.side_effect = HTTPStatusError(
             message='services "upf-external" not found',
             request=None,
             response=None,
         )
         self.harness.charm.on.remove.emit()
 
-        patch_client.return_value.delete.assert_called_once_with(
+        self.mock_charm_client.return_value.delete.assert_called_once_with(
             Service,
             name=f"{self.harness.charm.app.name}-external",
-            namespace=self.namespace,
+            namespace=NAMESPACE,
         )
 
-    @patch("lightkube.core.client.Client.create")
-    @patch("ops.model.Container.get_service")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_default_config_when_create_network_attachment_definitions_then_interface_mtu_not_set_in_the_network_attachment_definitions(  # noqa: E501
-        self, patch_get_service, kubernetes_create_object
+        self,
     ):
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_dpdk_is_configured.return_value = True
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
+        self.mock_get_service.return_value = service_info_mock
         self.harness.update_config(
             key_values={
                 "access-ip": "192.168.252.3/24",
@@ -1915,29 +1702,22 @@ class TestCharm(unittest.TestCase):
             }
         )
 
-        create_nad_calls = kubernetes_create_object.call_args_list
+        create_nad_calls = self.mock_client_create.call_args_list
         for create_nad_call in create_nad_calls:
             create_nad_call_args = next(
                 iter(filter(lambda call_item: isinstance(call_item, dict), create_nad_call))
             )
             nad_config = json.loads(create_nad_call_args.get("obj").spec.get("config"))
-            self.assertNotIn("mtu", nad_config)
+            assert "mtu" not in nad_config
 
-    @patch("charm.check_output")
-    @patch("lightkube.core.client.Client.list")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    @patch("dpdk.DPDK.is_configured")
     def test_given_cpu_supporting_required_hugepages_instructions_when_hugepages_enabled_then_charm_goes_to_waiting_status(  # noqa: E501
-        self,
-        patch_dpdk_is_configured,
-        patch_hugepages_is_patched,
-        patch_list,
-        patched_check_output,
+        self
     ):
-        patch_dpdk_is_configured.return_value = True
-        patch_hugepages_is_patched.return_value = True
-        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        patch_list.side_effect = [
+        self.mock_check_output = TestCharm.patcher_check_output.start()
+        self.mock_dpdk_is_configured.return_value = True
+        self.mock_is_patched.return_value = True
+        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1955,20 +1735,15 @@ class TestCharm(unittest.TestCase):
         )
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for bessd container to be ready"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for bessd container to be ready")
 
-    @patch("charm.check_output")
-    @patch("lightkube.core.client.Client.list")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_cpu_supporting_required_hugepages_instructions_and_not_available_hugepages_when_hugepages_enabled_then_charm_goes_to_blocked_status(  # noqa: E501
-        self, patch_hugepages_is_patched, patch_list, patched_check_output
+        self
     ):
-        patch_hugepages_is_patched.return_value = False
-        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        patch_list.return_value = [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "1Gi"}))]
+        self.mock_check_output = TestCharm.patcher_check_output.start()
+        self.mock_is_patched.return_value = False
+        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        self.mock_client_list.return_value = [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "1Gi"}))]
 
         self.harness.update_config(
             key_values={
@@ -1980,26 +1755,16 @@ class TestCharm(unittest.TestCase):
         )
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Not enough HugePages available"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Not enough HugePages available")
 
-    @patch("charm.check_output")
-    @patch("lightkube.core.client.Client.list")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    @patch("dpdk.DPDK.is_configured")
     def test_given_hugepages_not_available_then_hugepages_available_when_update_status_then_charm_goes_to_waiting_status(  # noqa: E501
-        self,
-        patch_dpdk_is_configured,
-        patch_hugepages_is_patched,
-        patch_list,
-        patched_check_output,
+        self
     ):
-        patch_dpdk_is_configured.return_value = True
-        patch_hugepages_is_patched.return_value = True
-        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        patch_list.side_effect = [
+        self.mock_check_output = TestCharm.patcher_check_output.start()
+        self.mock_dpdk_is_configured.return_value = True
+        self.mock_is_patched.return_value = True
+        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "1Gi"}))],
             [],
             [],
@@ -2018,28 +1783,22 @@ class TestCharm(unittest.TestCase):
         )
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Not enough HugePages available"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Not enough HugePages available")
 
         self.harness.charm.on.update_status.emit()
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for bessd container to be ready"),
-        )
-
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for bessd container to be ready")
+"""
     @patch("charm.check_output")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.multus_is_available")
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_multus_disabled_then_enabled_when_update_status_then_status_is_active(
-        self, patch_hugepages_is_patched, patch_multus_available, patched_check_output
+        self, self.mock_is_patched, patch_multus_available, self.mock_check_output
     ):
-        patch_hugepages_is_patched.return_value = True
+        self.mock_is_patched.return_value = True
         patch_multus_available.side_effect = [False, False, False, True]
-        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        self.mock_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
         self.harness.charm.on.update_status.emit()
         self.harness.evaluate_status()
         self.assertEqual(
@@ -2056,9 +1815,9 @@ class TestCharm(unittest.TestCase):
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_no_interface_mtu_specified_in_nad(  # noqa: E501
         self,
-        patch_hugepages_is_patched,
+        self.mock_is_patched,
     ):
-        patch_hugepages_is_patched.return_value = True
+        self.mock_is_patched.return_value = True
         self.harness.update_config(
             key_values={
                 "access-ip": "192.168.252.3/24",
@@ -2082,11 +1841,11 @@ class TestCharm(unittest.TestCase):
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
     @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_default_config_with_interfaces_mtu_sizes_when_create_network_attachment_definitions_then_interface_mtu_set_in_the_network_attachment_definitions(  # noqa: E501
-        self, patch_get_service, kubernetes_create_object
+        self, self.mock_get_service, self.mock_client_create
     ):
         service_info_mock = Mock()
         service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
+        self.mock_get_service.return_value = service_info_mock
         self.harness.update_config(
             key_values={
                 "access-ip": "192.168.252.3/24",
@@ -2099,7 +1858,7 @@ class TestCharm(unittest.TestCase):
             }
         )
 
-        create_nad_calls = kubernetes_create_object.call_args_list
+        create_nad_calls = self.mock_client_create.call_args_list
         for create_nad_call in create_nad_calls:
             create_nad_call_args = next(
                 iter(filter(lambda call_item: isinstance(call_item, dict), create_nad_call))
@@ -2132,22 +1891,22 @@ class TestCharm(unittest.TestCase):
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_container_can_connect_bessd_pebble_ready_when_core_net_mtu_config_changed_to_a_different_valid_value_then_delete_pod_is_called(  # noqa: E501
         self,
-        patch_hugepages_is_patched,
-        patch_delete_pod,
-        patch_multus_is_ready,
-        patch_list_na_definitions,
+        self.mock_is_patched,
+        self.mock_delete_pod,
+        self.mock_multus_is_ready,
+        self.mock_list_na_definitions,
         _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        patch_hugepages_is_patched.return_value = True
-        patch_multus_is_ready.return_value = True
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
         update_nad_labels(original_nads, self.harness.charm.app.name)
-        patch_list_na_definitions.return_value = original_nads
+        self.mock_list_na_definitions.return_value = original_nads
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_1})
-        patch_delete_pod.assert_called_once()
+        self.mock_delete_pod.assert_called_once()
 
     @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
@@ -2157,26 +1916,26 @@ class TestCharm(unittest.TestCase):
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_container_can_connect_bessd_pebble_ready_when_core_net_mtu_config_changed_to_different_valid_values_then_delete_pod_called_twice(  # noqa: E501
         self,
-        patch_hugepages_is_patched,
-        patch_delete_pod,
-        patch_multus_is_ready,
-        patch_list_na_definitions,
+        self.mock_is_patched,
+        self.mock_delete_pod,
+        self.mock_multus_is_ready,
+        self.mock_list_na_definitions,
         _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        patch_hugepages_is_patched.return_value = True
-        patch_multus_is_ready.return_value = True
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
         update_nad_labels(original_nads, self.harness.charm.app.name)
-        patch_list_na_definitions.return_value = original_nads
+        self.mock_list_na_definitions.return_value = original_nads
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_1})
         modified_nads = self.harness.charm._network_attachment_definitions_from_config()
         update_nad_labels(modified_nads, self.harness.charm.app.name)
-        patch_list_na_definitions.return_value = modified_nads
+        self.mock_list_na_definitions.return_value = modified_nads
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})
-        self.assertEqual(patch_delete_pod.call_count, 2)
+        self.assertEqual(self.mock_delete_pod.call_count, 2)
 
     @patch("ops.model.Container.get_service")
     @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
@@ -2186,39 +1945,39 @@ class TestCharm(unittest.TestCase):
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_container_can_connect_bessd_pebble_ready_when_core_net_mtu_config_changed_to_same_valid_value_multiple_times_then_delete_pod_called_once(  # noqa: E501
         self,
-        patch_hugepages_is_patched,
-        patch_delete_pod,
-        patch_multus_is_ready,
-        patch_list_na_definitions,
+        self.mock_is_patched,
+        self.mock_delete_pod,
+        self.mock_multus_is_ready,
+        self.mock_list_na_definitions,
         _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        """Delete pod is called for the first config change, setting the same config value does not trigger pod restarts."""  # noqa: E501, W505
-        patch_hugepages_is_patched.return_value = True
-        patch_multus_is_ready.return_value = True
+        \"""Delete pod is called for the first config change, setting the same config value does not trigger pod restarts.\"""  # noqa: E501, W505
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
         update_nad_labels(original_nads, self.harness.charm.app.name)
-        patch_list_na_definitions.return_value = original_nads
+        self.mock_list_na_definitions.return_value = original_nads
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})
-        patch_delete_pod.assert_called_once()
+        self.mock_delete_pod.assert_called_once()
         nads_after_first_config_change = (
             self.harness.charm._network_attachment_definitions_from_config()
         )
         update_nad_labels(nads_after_first_config_change, self.harness.charm.app.name)
-        patch_list_na_definitions.return_value = nads_after_first_config_change
+        self.mock_list_na_definitions.return_value = nads_after_first_config_change
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})
-        patch_delete_pod.assert_called_once()
+        self.mock_delete_pod.assert_called_once()
         nads_after_second_config_change = (
             self.harness.charm._network_attachment_definitions_from_config()
         )
         update_nad_labels(nads_after_second_config_change, self.harness.charm.app.name)
         for nad in nads_after_second_config_change:
             nad.metadata.labels = {"app.juju.is/created-by": self.harness.charm.app.name}
-        patch_list_na_definitions.return_value = nads_after_second_config_change
+        self.mock_list_na_definitions.return_value = nads_after_second_config_change
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})
-        patch_delete_pod.assert_called_once()
+        self.mock_delete_pod.assert_called_once()
 
     @patch("ops.model.Container.get_service")
     @patch("charm.UPFOperatorCharm.delete_pod")
@@ -2226,15 +1985,16 @@ class TestCharm(unittest.TestCase):
     @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_hardware_checksum_is_enabled_when_value_changes_then_delete_pod_is_called_once(  # noqa: E501
         self,
-        patch_hugepages_is_patched,
-        patch_multus_is_ready,
-        patch_delete_pod,
+        self.mock_is_patched,
+        self.mock_multus_is_ready,
+        self.mock_delete_pod,
         _,
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        patch_hugepages_is_patched.return_value = True
-        patch_multus_is_ready.return_value = True
+        self.mock_is_patched.return_value = True
+        self.mock_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         self.harness.update_config(key_values={"enable-hw-checksum": False})
-        patch_delete_pod.assert_called_once()
+        self.mock_delete_pod.assert_called_once()
+"""

--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -101,7 +101,7 @@ class TestCharmInitialisation:
         request.addfinalizer(self.tearDown)
 
     def add_storage(self) -> None:
-        self.root = self.harness.get_filesystem_root("bessd")
+        self.root = self.harness.get_filesystem_root("bessd")  # type:ignore
         (self.root / "etc/bess/conf").mkdir(parents=True)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
# Description

PART 2: this PR includes `tests/unit/test_dpdk.py` and `TestCharmInitialisation` class in `tests/unit/test_charm.py`
Next: `TestCharm` class in `tests/unit/test_charm.py`

Remove `unittest` and use `pytest` framework to run the unit tests.

Actions on this PR:

Add a `@pytest.fixture` for harness
Add a `@pytest.fixture` to setup patches and mocks
Continue using `Mock`, `call` and `patch` from the `unittest.Mock` library
Use `assert` instead of `self.assert...` methods
Add a parameterized test using `@pytest.mark.parametrize`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
