### PR TITLE
chore: use pytest in TestCharm class

### DIFF
--- a/tests/unit/test_charm.py
+++ b/tests/unit/test_charm.py
@@ -2,7 +2,6 @@
 # See LICENSE file for licensing details.
 
 import json
-import unittest
 from unittest.mock import Mock, call, patch
 
 import pytest
@@ -25,10 +24,10 @@ from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Service
 from ops import ActiveStatus, BlockedStatus, MaintenanceStatus, WaitingStatus, testing
 from ops.pebble import ConnectionError
-from parameterized import parameterized  # type: ignore[import-untyped]
 
-MULTUS_LIBRARY_PATH = "charms.kubernetes_charm_libraries.v0.multus"
-HUGEPAGES_LIBRARY_PATH = "charms.kubernetes_charm_libraries.v0.hugepages_volumes_patch"
+MULTUS_LIBRARY = "charms.kubernetes_charm_libraries.v0.multus.KubernetesMultusCharmLib"
+K8S_CLIENT = "charms.kubernetes_charm_libraries.v0.multus.KubernetesClient"
+HUGEPAGES_LIBRARY = "charms.kubernetes_charm_libraries.v0.hugepages_volumes_patch.KubernetesHugePagesPatchCharmLib"  # noqa E501
 TOO_BIG_MTU_SIZE = 65536  # Out of range
 TOO_SMALL_MTU_SIZE = 1199  # Out of range
 ZERO_MTU_SIZE = 0  # Out of range
@@ -36,7 +35,6 @@ VALID_MTU_SIZE_1 = 65535  # Upper edge value
 VALID_MTU_SIZE_2 = 1200  # Lower edge value
 TEST_PFCP_PORT = 1234
 DEFAULT_ACCESS_IP = "192.168.252.3/24"
-INVALID_ACCESS_IP = "192.168.252.3/44"
 VALID_ACCESS_IP = "192.168.252.5/24"
 ACCESS_GW_IP = "192.168.252.1"
 GNB_SUBNET = "192.168.251.0/24"
@@ -48,7 +46,6 @@ VALID_CORE_MAC = "00-b0-d0-63-c2-36"
 INVALID_CORE_MAC = "wrong"
 NAMESPACE = "whatever"
 
-
 def read_file(path: str) -> str:
     """Read a file and return its content as a string."""
     with open(path, "r") as f:
@@ -56,25 +53,19 @@ def read_file(path: str) -> str:
     return content
 
 
-def update_nad_labels(nads: list[NetworkAttachmentDefinition], app_name: str) -> None:
-    """Set NetworkAttachmentDefinition metadata labels."""
+def set_nad_metadata_labels(nads: list[NetworkAttachmentDefinition], app_name: str) -> None:
     for nad in nads:
         nad.metadata.labels = {"app.juju.is/created-by": app_name}
-
 
 class TestCharmInitialisation:
 
     patcher_k8s_client = patch("lightkube.core.client.GenericSyncClient")
     patcher_check_output = patch("charm.check_output")
     patcher_client_list = patch("lightkube.core.client.Client.list")
-    patcher_delete_pod = patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.delete_pod")
-    patcher_huge_pages_is_patched = patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-    )
-    patcher_list_na_definitions = patch(
-        f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions"
-    )
-    patcher_multus_is_ready = patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
+    patcher_delete_pod = patch(f"{MULTUS_LIBRARY}.delete_pod")
+    patcher_huge_pages_is_patched = patch(f"{HUGEPAGES_LIBRARY}.is_patched",)
+    patcher_list_na_definitions = patch(f"{K8S_CLIENT}.list_network_attachment_definitions")
+    patcher_multus_is_ready = patch(f"{MULTUS_LIBRARY}.is_ready")
 
     @pytest.fixture()
     def setUp(self):
@@ -251,7 +242,7 @@ class TestCharmInitialisation:
         self.harness.set_can_connect(container="pfcp-agent", val=True)
         self.harness.begin()
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
-        update_nad_labels(original_nads, self.harness.charm.app.name)
+        set_nad_metadata_labels(original_nads, self.harness.charm.app.name)
         self.mock_list_na_definitions.return_value = original_nads
 
         self.harness.update_config(key_values={"core-interface-mtu-size": TOO_BIG_MTU_SIZE})
@@ -298,77 +289,127 @@ class TestCharmInitialisation:
             assert (ACCESS_INTERFACE_NAME or CORE_INTERFACE_NAME in config["master"])
             assert config["type"] == "macvlan"
 
-class TestCharm(unittest.TestCase):
+class TestCharm:
 
+    patcher_check_output = patch("charm.check_output")
+    patcher_client_apply = patch("lightkube.core.client.Client.apply")
+    patcher_client_create = patch("lightkube.core.client.Client.create")
+    patcher_client_delete = patch("lightkube.core.client.Client.delete")
+    patcher_client_get = patch("lightkube.core.client.Client.get")
+    patcher_client_list = patch("lightkube.core.client.Client.list")
+    patcher_delete_pod = patch(f"{MULTUS_LIBRARY}.delete_pod")
+    patcher_dpdk_is_configured = patch("charm.DPDK.is_configured")
+    patcher_get_service = patch("ops.model.Container.get_service")
+    patcher_huge_pages_is_patched = patch(f"{HUGEPAGES_LIBRARY}.is_patched")
+    patcher_k8s_client = patch("lightkube.core.client.GenericSyncClient")
+    patcher_k8s_statefulset_patch = patch("lightkube.core.client.Client.patch")
+    patcher_list_na_definitions = patch(f"{K8S_CLIENT}.list_network_attachment_definitions")
+    patcher_multus_is_ready = patch(f"{MULTUS_LIBRARY}.is_ready")
+    patcher_pfcp_port = patch("charm.PFCP_PORT", TEST_PFCP_PORT)
+    patcher_publish_upf_n3_information = patch(
+        "charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information"
+    )
+    patcher_publish_upf_n4_information = patch(
+        "charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information"
+    )
+
+    @pytest.fixture()
     def setUp(self):
-        self.patch_k8s_client = patch("lightkube.core.client.GenericSyncClient")
-        self.patch_k8s_client.start()
-        self.namespace = "whatever"
+        TestCharm.patcher_k8s_client.start()
+        TestCharm.patcher_pfcp_port.start()
+        self.mock_client_apply = TestCharm.patcher_client_apply.start()
+        self.mock_client_create = TestCharm.patcher_client_create.start()
+        self.mock_client_get = TestCharm.patcher_client_get.start()
+        self.mock_client_list = TestCharm.patcher_client_list.start()
+        self.mock_client_delete = TestCharm.patcher_client_delete.start()
+        self.mock_dpdk_is_configured = TestCharm.patcher_dpdk_is_configured.start()
+        self.mock_get_service = TestCharm.patcher_get_service.start()
+        self.mock_huge_pages_is_enabled = TestCharm.patcher_huge_pages_is_patched.start()
+        self.mock_k8s_statefulset_patch = TestCharm.patcher_k8s_statefulset_patch.start()
+        self.mock_multus_is_ready = TestCharm.patcher_multus_is_ready.start()
+        self.mock_publish_upf_n3_information = TestCharm.patcher_publish_upf_n3_information.start()
+        self.mock_publish_upf_n4_information = TestCharm.patcher_publish_upf_n4_information.start()
+
+    @staticmethod
+    def tearDown() -> None:
+        patch.stopall()
+
+    @pytest.fixture(autouse=True)
+    def harness(self, setUp, request):
         self.harness = testing.Harness(UPFOperatorCharm)
-        self.harness.set_model_name(name=self.namespace)
+        self.harness.set_model_name(name=NAMESPACE)
         self.harness.set_leader(is_leader=True)
-
-        self.maxDiff = None
-        self.root = self.harness.get_filesystem_root("bessd")
-        (self.root / "etc/bess/conf").mkdir(parents=True)
-        self.addCleanup(self.harness.cleanup)
+        self.set_up_storage()
         self.harness.begin()
+        yield self.harness
+        self.harness.cleanup()
+        request.addfinalizer(self.tearDown)
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
+    @pytest.fixture()
+    def set_can_connect_containers(self) -> None:
+        self.harness.set_can_connect("bessd", True)  # type:ignore
+        self.harness.set_can_connect("pfcp-agent", True)  # type:ignore
+
+    @pytest.fixture()
+    def enable_huge_pages_multus_and_dpdk(self) -> None:
+        self.mock_huge_pages_is_enabled.return_value = True
+        self.mock_multus_is_ready.return_value = True
+        self.mock_dpdk_is_configured.return_value = True
+
+    def set_up_storage(self) -> None:
+        self.root = self.harness.get_filesystem_root("bessd")  # type:ignore
+        (self.root / "etc/bess/conf").mkdir(parents=True)
+
+    def mock_running_service(self) -> None:
+        service_info_mock = Mock()
+        service_info_mock.is_running.return_value = True
+        self.mock_get_service.return_value = service_info_mock
+
+    def add_fiveg_n3_relation(self) -> int:
+        relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")  # type:ignore
+        self.harness.add_relation_unit(relation_id, "n3_requirer_app/0")  # type:ignore
+        return relation_id
+
+    def add_fiveg_n4_relation(self) -> int:
+        relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")  # type:ignore
+        self.harness.add_relation_unit(relation_id, "n4_requirer_app/0")  # type:ignore
+        return relation_id
+
     def test_given_bessd_config_file_not_yet_written_when_bessd_pebble_ready_then_config_file_is_written(  # noqa: E501
-        self,
-        _,
-        __,
+        self, set_can_connect_containers
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.container_pebble_ready(container_name="bessd")
         expected_config_file_content = read_file("tests/unit/expected_upf.json").strip()
 
-        self.assertEqual(
-            (self.root / "etc/bess/conf/upf.json").read_text(), expected_config_file_content
-        )
+        assert (self.root / "etc/bess/conf/upf.json").read_text() == expected_config_file_content
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bessd_config_file_not_yet_written_when_config_storage_attached_then_config_file_is_written(  # noqa: E501
-        self, _, __
+        self, set_can_connect_containers
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         (self.root / "etc/bess/conf").rmdir()
         self.harness.add_storage(storage_name="config", count=1)
         self.harness.attach_storage(storage_id="config/0")
 
         expected_config_file_content = read_file("tests/unit/expected_upf.json").strip()
 
-        self.assertEqual(
-            (self.root / "etc/bess/conf/upf.json").read_text(), expected_config_file_content
-        )
+        assert (self.root / "etc/bess/conf/upf.json").read_text() == expected_config_file_content
 
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bessd_config_file_matches_when_bessd_pebble_ready_then_config_file_is_not_changed(  # noqa: E501
-        self,
-        patch_is_ready,
+        self
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
         expected_upf_content = read_file("tests/unit/expected_upf.json").strip()
         (self.root / "etc/bess/conf/upf.json").write_text(expected_upf_content)
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        self.assertEqual((self.root / "etc/bess/conf/upf.json").read_text(), expected_upf_content)
+        assert (self.root / "etc/bess/conf/upf.json").read_text() == expected_upf_content
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bess_configured_when_bessd_pebble_ready_then_expected_pebble_plan_is_applied(  # noqa: E501
-        self,
-        patch_is_ready,
-        _,
+        self, set_can_connect_containers
     ):
         grpc_check_cmd = "/opt/bess/bessctl/bessctl show version".split()
         accessRoutes_check_cmd = "/opt/bess/bessctl/bessctl show module accessRoutes".split()  # noqa: N806
@@ -383,9 +424,7 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", coreRoutes_check_cmd, result=0)
         self.harness.handle_exec("bessd", config_check_cmd, result="RUNNING")
         self.harness.handle_exec("bessd", bessctl_cmd, result=0)
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
         expected_plan = {
@@ -417,17 +456,11 @@ class TestCharm(unittest.TestCase):
                 }
             },
         }
-
         updated_plan = self.harness.get_container_pebble_plan("bessd").to_dict()
+        assert expected_plan == updated_plan
 
-        self.assertEqual(expected_plan, updated_plan)
-
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_bess_not_configured_when_bessd_pebble_ready_then_routectl_service_not_started(  # noqa: E501
-        self,
-        patch_is_ready,
-        _,
+        self, set_can_connect_containers
     ):
         grpc_check_cmd = "/opt/bess/bessctl/bessctl show version".split()
         accessRoutes_check_cmd = "/opt/bess/bessctl/bessctl show module accessRoutes".split()  # noqa: N806
@@ -442,21 +475,15 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", coreRoutes_check_cmd, result=0)
         self.harness.handle_exec("bessd", config_check_cmd, result="RUNNING")
         self.harness.handle_exec("bessd", bessctl_cmd, result=0)
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        self.assertNotIn("routectl", self.harness.get_container_pebble_plan("bessd").services)
+        assert "routectl" not in self.harness.get_container_pebble_plan("bessd").services
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_can_connect_to_bessd_when_bessd_pebble_ready_then_ip_route_is_created(
-        self, patch_is_ready, _
+        self, set_can_connect_containers
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         ip_route_replace_called = False
         timeout = 0
         environment = {}
@@ -488,21 +515,17 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", ["iptables-legacy"], result=0)
         self.harness.handle_exec("bessd", ["/opt/bess/bessctl/bessctl"], result=0)
         self.harness.handle_exec("bessd", ip_route_show_cmd, result="")
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        self.assertTrue(ip_route_replace_called)
-        self.assertEqual(timeout, 30)
-        self.assertEqual(environment, {})
+        assert ip_route_replace_called
+        assert timeout == 30
+        assert environment == {}
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_can_connect_to_bessd_when_bessd_pebble_ready_then_gnb_subnet_route_is_created(
-        self, patch_is_ready, _
+        self, set_can_connect_containers
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         gnb_subnet_route_replace_called = False
         timeout = 0
         environment = {}
@@ -534,21 +557,17 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", ["iptables-legacy"], result=0)
         self.harness.handle_exec("bessd", ["/opt/bess/bessctl/bessctl"], result=0)
         self.harness.handle_exec("bessd", ip_route_show_cmd, result="")
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        self.assertTrue(gnb_subnet_route_replace_called)
-        self.assertEqual(timeout, 30)
-        self.assertEqual(environment, {})
+        assert gnb_subnet_route_replace_called
+        assert timeout == 30
+        assert environment == {}
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_iptables_rule_is_not_yet_created_when_bessd_pebble_ready_then_rule_is_created(
-        self, patch_is_ready, _
+        self, set_can_connect_containers
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         iptables_drop_called = False
         timeout = 0
         environment = {}
@@ -589,20 +608,17 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", iptables_check_cmd, result=1)
         self.harness.handle_exec("bessd", iptables_drop_cmd, handler=iptables_handler)
         self.harness.handle_exec("bessd", ["/opt/bess/bessctl/bessctl"], result=0)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
-        self.assertTrue(iptables_drop_called)
-        self.assertEqual(timeout, 30)
-        self.assertEqual(environment, {})
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
+        assert iptables_drop_called
+        assert timeout == 30
+        assert environment == {}
+
     def test_given_iptables_rule_is_created_when_bessd_pebble_ready_then_rule_is_not_re_created(
-        self, patch_is_ready, _
+        self, set_can_connect_containers
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         iptables_drop_called = False
 
         iptables_drop_cmd = [
@@ -626,26 +642,27 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", iptables_drop_cmd, handler=iptables_handler)
         self.harness.handle_exec("bessd", ["iptables-legacy"], result=0)
         self.harness.handle_exec("bessd", ["/opt/bess/bessctl/bessctl"], result=0)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        self.assertFalse(iptables_drop_called)
+        assert not iptables_drop_called
 
-    @parameterized.expand(
+    @pytest.mark.parametrize(
+        "access_routes_check_out, core_routes_check_out, config_check_out",
         [
-            [1, 0, "RUNNING"],
-            [0, 1, "RUNNING"],
-            [0, 0, 1],
+            (1, 0, "RUNNING"),
+            (0, 1, "RUNNING"),
+            (0, 0, 1),
         ]
     )
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_can_connect_to_bessd_when_bessd_pebble_ready_then_bessctl_configure_is_executed(
-        self, accessRoutes_check_out, coreRoutes_check_out, config_check_out, patch_is_ready, _  # noqa: N803
+        self,
+        access_routes_check_out,
+        core_routes_check_out,
+        config_check_out,
+        set_can_connect_containers
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         bessctl_called = False
         timeout = 0
         environment = {}
@@ -668,30 +685,22 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", ["ip"], result=0)
         self.harness.handle_exec("bessd", ["iptables-legacy"], result=0)
         self.harness.handle_exec("bessd", grpc_check_cmd, result=0)
-        self.harness.handle_exec("bessd", accessRoutes_check_cmd, result=accessRoutes_check_out)
-        self.harness.handle_exec("bessd", coreRoutes_check_cmd, result=coreRoutes_check_out)
+        self.harness.handle_exec("bessd", accessRoutes_check_cmd, result=access_routes_check_out)
+        self.harness.handle_exec("bessd", coreRoutes_check_cmd, result=core_routes_check_out)
         self.harness.handle_exec("bessd", config_check_cmd, result=config_check_out)
         self.harness.handle_exec("bessd", bessctl_cmd, handler=bessctl_handler)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        self.assertTrue(bessctl_called)
-        self.assertEqual(timeout, 30)
-        self.assertEqual(
-            environment, {"CONF_FILE": "/etc/bess/conf/upf.json", "PYTHONPATH": "/opt/bess"}
-        )
+        assert bessctl_called
+        assert timeout == 30
+        assert environment == {"CONF_FILE": "/etc/bess/conf/upf.json", "PYTHONPATH": "/opt/bess"}
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_connects_and_bess_configured_then_bessctl_configure_not_executed(
-        self, patch_is_ready, _
+        self, set_can_connect_containers
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
-
         bessctl_called = False
-
         grpc_check_cmd = "/opt/bess/bessctl/bessctl show version".split()
         accessRoutes_check_cmd = "/opt/bess/bessctl/bessctl show module accessRoutes".split()  # noqa: N806
         coreRoutes_check_cmd = "/opt/bess/bessctl/bessctl show module coreRoutes".split()  # noqa: N806
@@ -710,82 +719,58 @@ class TestCharm(unittest.TestCase):
         self.harness.handle_exec("bessd", coreRoutes_check_cmd, result=0)
         self.harness.handle_exec("bessd", config_check_cmd, result="RUNNING")
         self.harness.handle_exec("bessd", bessctl_cmd, handler=bessctl_handler)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
 
         self.harness.container_pebble_ready(container_name="bessd")
 
-        self.assertFalse(bessctl_called)
+        assert not bessctl_called
 
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    def test_given_storage_not_attached_when_bessd_pebble_ready_then_status_is_waiting(
-        self,
-        patch_is_ready,
+    def test_given_storage_not_attached_when_collect_status_ready_then_status_is_waiting(
+        self, set_can_connect_containers
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
         ip_route_show_result = f"{GNB_SUBNET} via {ACCESS_GW_IP}\ndefault via {CORE_GW_IP}"
 
         self.harness.handle_exec("bessd", ip_route_show_cmd, result=ip_route_show_result)
         self.harness.handle_exec("bessd", [], result=0)
-        patch_is_ready.return_value = True
+        self.mock_multus_is_ready.return_value = True
         (self.root / "etc/bess/conf").rmdir()
 
-        self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for storage to be attached"),
+        assert self.harness.model.unit.status == WaitingStatus(
+            "Waiting for storage to be attached"
         )
 
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    def test_given_multus_not_configured_when_bessd_pebble_ready_then_status_is_waiting(
-        self,
-        patch_is_ready,
+    def test_given_multus_not_configured_when_collect_status_then_status_is_waiting(
+        self, set_can_connect_containers
     ):
-        patch_is_ready.return_value = False
+        self.mock_multus_is_ready.return_value = False
 
-        self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for Multus to be ready"),
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for Multus to be ready")
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    def test_given_config_file_is_written_and_all_services_are_running_when_bessd_pebble_ready_then_status_is_active(  # noqa: E501
-        self,
-        patch_is_ready,
-        patch_get_service,
+    def test_given_config_file_is_written_and_all_services_are_running_when_collect_status_then_status_is_active(  # noqa: E501
+        self, set_can_connect_containers
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
         ip_route_show_result = f"{GNB_SUBNET} via {ACCESS_GW_IP}\ndefault via {CORE_GW_IP}"
 
         self.harness.handle_exec("bessd", ip_route_show_cmd, result=ip_route_show_result)
         self.harness.handle_exec("bessd", [], result="RUNNING")
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patch_is_ready.return_value = True
-        self.harness.set_can_connect(container="pfcp-agent", val=True)
+        self.mock_running_service()
+        self.mock_multus_is_ready.return_value = True
 
-        self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        self.assertEqual(self.harness.model.unit.status, ActiveStatus())
+        assert self.harness.model.unit.status == ActiveStatus()
 
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    @patch("ops.model.Container.get_service")
     def test_given_bessd_service_is_running_when_pfcp_agent_pebble_ready_then_pebble_plan_is_applied(  # noqa: E501
         self,
-        patch_get_service,
-        patch_multus_is_ready,
     ):
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patch_multus_is_ready.return_value = True
+        self.mock_running_service()
+        self.mock_multus_is_ready.return_value = True
         self.harness.set_can_connect(container="bessd", val=True)
         grpc_check_cmd = "/opt/bess/bessctl/bessctl show version".split()
         accessRoutes_check_cmd = "/opt/bess/bessctl/bessctl show module accessRoutes".split()  # noqa: N806
@@ -802,7 +787,7 @@ class TestCharm(unittest.TestCase):
 
         self.harness.container_pebble_ready(container_name="pfcp-agent")
         self.harness.evaluate_status()
-        self.assertEqual(self.harness.charm.unit.status, ActiveStatus())
+        assert self.harness.charm.unit.status == ActiveStatus()
 
         expected_plan = {
             "services": {
@@ -813,131 +798,90 @@ class TestCharm(unittest.TestCase):
                 }
             }
         }
-
         updated_plan = self.harness.get_container_pebble_plan("pfcp-agent").to_dict()
+        assert expected_plan == updated_plan
 
-        self.assertEqual(expected_plan, updated_plan)
-
-    def test_given_cant_connect_to_bessd_container_when_pfcp_agent_pebble_ready_then_status_is_waiting(  # noqa: E501
-        self,
+    def test_given_cant_connect_to_bessd_container_when_collect_status_then_status_is_waiting(  # noqa: E501
+        self
     ):
         self.harness.set_can_connect(container="bessd", val=False)
 
-        self.harness.container_pebble_ready(container_name="pfcp-agent")
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for bessd container to be ready"),
+        assert self.harness.model.unit.status == WaitingStatus(
+            "Waiting for bessd container to be ready"
         )
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    def test_given_pebble_connection_error_when_bessd_pebble_ready_then_status_is_waiting(  # noqa: E501
-        self, patch_is_ready, patch_get_service
+    def test_given_pebble_connection_error_when_collect_status_then_status_is_waiting(  # noqa: E501
+        self, set_can_connect_containers
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
         ip_route_show_result = f"{GNB_SUBNET} via {ACCESS_GW_IP}\ndefault via {CORE_GW_IP}"
-
         self.harness.handle_exec("bessd", ip_route_show_cmd, result=ip_route_show_result)
         self.harness.handle_exec("bessd", [], result=0)
-        patch_get_service.side_effect = ConnectionError()
-        patch_is_ready.return_value = True
-        self.harness.set_can_connect(container="bessd", val=True)
+        self.mock_get_service.side_effect = ConnectionError()
+        self.mock_multus_is_ready.return_value = True
 
-        self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for bessd service to run")
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for bessd service to run")
 
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    def test_given_default_route_not_created_when_bessd_pebble_ready_then_status_is_waiting(
-        self, patch_is_ready
+    def test_given_default_route_not_created_when_collect_status_then_status_is_waiting(
+        self, set_can_connect_containers
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
-
         self.harness.handle_exec("bessd", ip_route_show_cmd, result="")
         self.harness.handle_exec("bessd", [], result=0)
-        patch_is_ready.return_value = True
-        self.harness.set_can_connect(container="bessd", val=True)
+        self.mock_multus_is_ready.return_value = True
 
-        self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for default route creation")
+        assert self.harness.model.unit.status == WaitingStatus(
+            "Waiting for default route creation"
         )
 
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    def test_given_ran_route_not_created_when_bessd_pebble_ready_then_status_is_waiting(
-        self, patch_is_ready
+    def test_given_ran_route_not_created_when_collect_status_then_status_is_waiting(
+        self, set_can_connect_containers
     ):
         ip_route_show_cmd = ["ip", "route", "show"]
-
         self.harness.handle_exec("bessd", ip_route_show_cmd, result=f"default via {CORE_GW_IP}")
         self.harness.handle_exec("bessd", [], result=0)
-        patch_is_ready.return_value = True
-        self.harness.set_can_connect(container="bessd", val=True)
+        self.mock_multus_is_ready.return_value = True
 
-        self.harness.container_pebble_ready(container_name="bessd")
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status, WaitingStatus("Waiting for RAN route creation")
-        )
+        assert self.harness.model.unit.status == WaitingStatus("Waiting for RAN route creation")
 
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
     def test_given_fiveg_n3_relation_created_when_fiveg_n3_request_then_upf_ip_address_is_published(  # noqa: E501
-        self,
-        patched_publish_upf_information,
-        patch_hugepages_is_patched,
+        self
     ):
-        patch_hugepages_is_patched.return_value = True
         test_upf_access_ip_cidr = "1.2.3.4/21"
         self.harness.update_config(key_values={"access-ip": test_upf_access_ip_cidr})
 
-        n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
-        self.harness.add_relation_unit(n3_relation_id, "n3_requirer_app/0")
+        n3_relation_id = self.add_fiveg_n3_relation()
 
-        patched_publish_upf_information.assert_called_once_with(
+        self.mock_publish_upf_n3_information.assert_called_once_with(
             relation_id=n3_relation_id, upf_ip_address=test_upf_access_ip_cidr.split("/")[0]
         )
 
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
     def test_given_unit_is_not_leader_when_fiveg_n3_request_then_upf_ip_address_is_not_published(
-        self, patched_publish_upf_information
+        self
     ):
         self.harness.set_leader(is_leader=False)
         test_upf_access_ip_cidr = "1.2.3.4/21"
         self.harness.update_config(key_values={"access-ip": test_upf_access_ip_cidr})
 
-        n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
-        self.harness.add_relation_unit(n3_relation_id, "n3_requirer_app/0")
+        self.add_fiveg_n3_relation()
 
-        patched_publish_upf_information.assert_not_called()
+        self.mock_publish_upf_n3_information.assert_not_called()
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_fiveg_n3_relation_exists_when_access_ip_config_changed_then_new_upf_ip_address_is_published(  # noqa: E501
-        self,
-        patch_multus_is_ready,
-        patch_hugepages_is_patched,
-        patched_publish_upf_information,
-        _,
+        self, set_can_connect_containers
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        patch_multus_is_ready.return_value = True
-        patch_hugepages_is_patched.return_value = True
-        self.harness.set_can_connect(container="bessd", val=True)
-        self.harness.set_can_connect(container="pfcp-agent", val=True)
-        n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
-        self.harness.add_relation_unit(n3_relation_id, "n3_requirer_app/0")
+        self.mock_multus_is_ready.return_value = True
+        self.mock_huge_pages_is_enabled.return_value = True
+        n3_relation_id = self.add_fiveg_n3_relation()
         test_upf_access_ip_cidr = "1.2.3.4/21"
         expected_calls = [
             call(relation_id=n3_relation_id, upf_ip_address="192.168.252.3"),
@@ -946,30 +890,24 @@ class TestCharm(unittest.TestCase):
 
         self.harness.update_config(key_values={"access-ip": test_upf_access_ip_cidr})
 
-        patched_publish_upf_information.assert_has_calls(expected_calls)
+        self.mock_publish_upf_n3_information.assert_has_calls(expected_calls)
 
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n3.N3Provides.publish_upf_information")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
     def test_given_fiveg_n3_relation_exists_when_access_ip_config_changed_to_invalid_cidr_then_new_upf_ip_address_is_not_published(  # noqa: E501
-        self, patch_multus_is_ready, patched_publish_upf_information
+        self, set_can_connect_containers
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        patch_multus_is_ready.return_value = True
-        self.harness.set_can_connect(container="bessd", val=True)
-        self.harness.set_can_connect(container="pfcp-agent", val=True)
-        n3_relation_id = self.harness.add_relation("fiveg_n3", "n3_requirer_app")
-        self.harness.add_relation_unit(n3_relation_id, "n3_requirer_app/0")
-        invalid_test_upf_access_ip_cidr = "1111.2.3.4/21"
+        self.mock_multus_is_ready.return_value = True
+        n3_relation_id = self.add_fiveg_n3_relation()
 
+        invalid_test_upf_access_ip_cidr = "1111.2.3.4/21"
         self.harness.update_config(key_values={"access-ip": invalid_test_upf_access_ip_cidr})
 
-        patched_publish_upf_information.assert_called_once_with(
+        self.mock_publish_upf_n3_information.assert_called_once_with(
             relation_id=n3_relation_id, upf_ip_address="192.168.252.3"
         )
 
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
     def test_given_unit_is_not_leader_when_fiveg_n4_request_then_upf_hostname_is_not_published(
-        self, patched_publish_upf_n4_information
+        self
     ):
         self.harness.set_leader(is_leader=False)
         test_external_upf_hostname = "test-upf.external.hostname.com"
@@ -977,39 +915,28 @@ class TestCharm(unittest.TestCase):
             key_values={"external-upf-hostname": test_external_upf_hostname}
         )
 
-        n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
-        self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
+        self.add_fiveg_n4_relation()
 
-        patched_publish_upf_n4_information.assert_not_called()
+        self.mock_publish_upf_n4_information.assert_not_called()
 
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
-    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_set_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
-        self,
-        patched_publish_upf_n4_information,
-        patch_hugepages_is_patched,
+        self
     ):
-        patch_hugepages_is_patched.return_value = True
         test_external_upf_hostname = "test-upf.external.hostname.com"
         self.harness.update_config(
             key_values={"external-upf-hostname": test_external_upf_hostname}
         )
 
-        n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
-        self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
+        n4_relation_id = self.add_fiveg_n4_relation()
 
-        patched_publish_upf_n4_information.assert_called_once_with(
+        self.mock_publish_upf_n4_information.assert_called_once_with(
             relation_id=n4_relation_id,
             upf_hostname=test_external_upf_hostname,
             upf_n4_port=TEST_PFCP_PORT,
         )
 
-    @patch("lightkube.core.client.Client.get")
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
-    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_not_set_but_external_upf_service_hostname_available_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
-        self, patched_publish_upf_n4_information, patched_lightkube_client_get
+        self
     ):
         test_external_upf_service_hostname = "test-upf.external.service.hostname.com"
         service = Mock(
@@ -1019,76 +946,60 @@ class TestCharm(unittest.TestCase):
                 )
             )
         )
-        patched_lightkube_client_get.return_value = service
+        self.mock_client_get.return_value = service
 
-        n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
-        self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
+        n4_relation_id = self.add_fiveg_n4_relation()
 
-        patched_publish_upf_n4_information.assert_called_once_with(
+        self.mock_publish_upf_n4_information.assert_called_once_with(
             relation_id=n4_relation_id,
             upf_hostname=test_external_upf_service_hostname,
             upf_n4_port=TEST_PFCP_PORT,
         )
 
-    @patch("lightkube.core.client.Client.get")
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
-    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_not_set_and_external_upf_service_hostname_not_available_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
-        self, patched_publish_upf_n4_information, patched_lightkube_client_get
+        self,
     ):
         service = Mock(status=Mock(loadBalancer=Mock(ingress=[Mock(ip="1.1.1.1", spec=["ip"])])))
-        patched_lightkube_client_get.return_value = service
+        self.mock_client_get.return_value = service
 
-        n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
-        self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
+        n4_relation_id = self.add_fiveg_n4_relation()
 
-        patched_publish_upf_n4_information.assert_called_once_with(
+        self.mock_publish_upf_n4_information.assert_called_once_with(
             relation_id=n4_relation_id,
-            upf_hostname=f"{self.harness.charm.app.name}-external.{self.namespace}"
+            upf_hostname=f"{self.harness.charm.app.name}-external.{NAMESPACE}"
             ".svc.cluster.local",
             upf_n4_port=TEST_PFCP_PORT,
         )
 
-    @patch("lightkube.core.client.Client.get")
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
-    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_external_upf_hostname_config_not_set_and_metallb_not_available_and_fiveg_n4_relation_created_when_fiveg_n4_request_then_upf_hostname_and_n4_port_is_published(  # noqa: E501
-        self, patched_publish_upf_n4_information, patched_lightkube_client_get
+        self
     ):
         service = Mock(status=Mock(loadBalancer=Mock(ingress=None)))
-        patched_lightkube_client_get.return_value = service
+        self.mock_client_get.return_value = service
 
-        n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
-        self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
+        n4_relation_id = self.add_fiveg_n4_relation()
 
-        patched_publish_upf_n4_information.assert_called_once_with(
+        self.mock_publish_upf_n4_information.assert_called_once_with(
             relation_id=n4_relation_id,
-            upf_hostname=f"{self.harness.charm.app.name}-external.{self.namespace}"
+            upf_hostname=f"{self.harness.charm.app.name}-external.{NAMESPACE}"
             ".svc.cluster.local",
             upf_n4_port=TEST_PFCP_PORT,
         )
 
-    @patch("ops.model.Container.get_service")
-    @patch("charms.sdcore_upf_k8s.v0.fiveg_n4.N4Provides.publish_upf_n4_information")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    @patch("charm.PFCP_PORT", TEST_PFCP_PORT)
     def test_given_fiveg_n4_relation_exists_when_external_upf_hostname_config_changed_then_new_upf_hostname_is_published(  # noqa: E501
-        self,
-        patch_multus_is_ready,
-        patch_hugepages_is_ready,
-        patched_publish_upf_n4_information,
-        _,
+        self, set_can_connect_containers
     ):
         self.harness.handle_exec("bessd", [], result=0)
         test_external_upf_hostname = "test-upf.external.hostname.com"
-        patch_multus_is_ready.return_value = True
-        patch_hugepages_is_ready.return_value = True
-        self.harness.set_can_connect(container="bessd", val=True)
-        self.harness.set_can_connect(container="pfcp-agent", val=True)
+        self.mock_multus_is_ready.return_value = True
+        self.mock_huge_pages_is_enabled.return_value = True
         self.harness.update_config(key_values={"external-upf-hostname": "whatever.com"})
-        n4_relation_id = self.harness.add_relation("fiveg_n4", "n4_requirer_app")
-        self.harness.add_relation_unit(n4_relation_id, "n4_requirer_app/0")
+        n4_relation_id = self.add_fiveg_n4_relation()
+
+        self.harness.update_config(
+            key_values={"external-upf-hostname": test_external_upf_hostname}
+        )
+
         expected_calls = [
             call(
                 relation_id=n4_relation_id, upf_hostname="whatever.com", upf_n4_port=TEST_PFCP_PORT
@@ -1099,19 +1010,12 @@ class TestCharm(unittest.TestCase):
                 upf_n4_port=TEST_PFCP_PORT,
             ),
         ]
+        self.mock_publish_upf_n4_information.assert_has_calls(expected_calls)
 
-        self.harness.update_config(
-            key_values={"external-upf-hostname": test_external_upf_hostname}
-        )
-
-        patched_publish_upf_n4_information.assert_has_calls(expected_calls)
-
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_no_interface_specified_in_nad(  # noqa: E501
         self,
-        patch_hugepages_is_patched,
     ):
-        patch_hugepages_is_patched.return_value = True
+        self.mock_huge_pages_is_enabled.return_value = True
         self.harness.update_config(
             key_values={
                 "access-ip": DEFAULT_ACCESS_IP,
@@ -1124,28 +1028,15 @@ class TestCharm(unittest.TestCase):
         nads = self.harness.charm._network_attachment_definitions_from_config()
         for nad in nads:
             config = json.loads(nad.spec["config"])
-            self.assertNotIn("master", config)
-            self.assertEqual("bridge", config["type"])
-            self.assertIn(config["bridge"], ("core-br", "access-br"))
+            assert "master" not in config
+            assert "bridge" == config["type"]
+            assert config["bridge"] in ("core-br", "access-br")
 
-    @patch("lightkube.core.client.Client.create")
-    @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.Client.list")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_configured_to_run_in_dpdk_mode_when_create_network_attachment_definitions_then_2_nads_are_returned(  # noqa: E501
-        self, patched_list, patch_get_service, kubernetes_create_object
+        self, set_can_connect_containers, enable_huge_pages_multus_and_dpdk
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patched_list.side_effect = [
+        self.mock_running_service()
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1161,27 +1052,14 @@ class TestCharm(unittest.TestCase):
             }
         )
 
-        create_nad_calls = kubernetes_create_object.call_args_list
-        self.assertEqual(len(create_nad_calls), 2)
+        create_nad_calls = self.mock_client_create.call_args_list
+        assert len(create_nad_calls) == 2
 
-    @patch("lightkube.core.client.Client.create")
-    @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.Client.list")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_configured_to_run_in_dpdk_mode_when_create_network_attachment_definitions_then_nad_type_is_vfioveth(  # noqa: E501
-        self, patched_list, patch_get_service, kubernetes_create_object
+        self, set_can_connect_containers, enable_huge_pages_multus_and_dpdk
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patched_list.side_effect = [
+        self.mock_running_service()
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
             [],
@@ -1196,32 +1074,19 @@ class TestCharm(unittest.TestCase):
             }
         )
 
-        create_nad_calls = kubernetes_create_object.call_args_list
+        create_nad_calls = self.mock_client_create.call_args_list
         for create_nad_call in create_nad_calls:
             create_nad_call_args = next(
                 iter(filter(lambda call_item: isinstance(call_item, dict), create_nad_call))
             )
             nad_config = json.loads(create_nad_call_args.get("obj").spec.get("config"))
-            self.assertEqual(nad_config["type"], "vfioveth")
+            assert nad_config["type"] == "vfioveth"
 
-    @patch("lightkube.core.client.Client.create")
-    @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.Client.list")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_configured_to_run_in_dpdk_mode_when_create_network_attachment_definitions_then_access_nad_has_valid_dpdk_access_resource_specified_in_annotations(  # noqa: E501
-        self, patched_list, patch_get_service, kubernetes_create_object
+        self, set_can_connect_containers, enable_huge_pages_multus_and_dpdk
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patched_list.side_effect = [
+        self.mock_running_service()
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1250,37 +1115,21 @@ class TestCharm(unittest.TestCase):
                 None,
             )
 
-        create_nad_calls = kubernetes_create_object.mock_calls
+        create_nad_calls = self.mock_client_create.mock_calls
         create_access_nad_calls = [
             _get_create_access_nad_call(create_nad_call)
             for create_nad_call in create_nad_calls
             if _get_create_access_nad_call(create_nad_call)
         ]
-        self.assertEqual(len(create_access_nad_calls), 1)
+        assert len(create_access_nad_calls) == 1
         nad_annotations = create_access_nad_calls[0].get("obj").metadata.annotations
-        self.assertTrue(
-            DPDK_ACCESS_INTERFACE_RESOURCE_NAME
-            in nad_annotations["k8s.v1.cni.cncf.io/resourceName"]
-        )
+        assert DPDK_ACCESS_INTERFACE_RESOURCE_NAME in nad_annotations["k8s.v1.cni.cncf.io/resourceName"]  # noqa: E501
 
-    @patch("lightkube.core.client.Client.create")
-    @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.Client.list")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_configured_to_run_in_dpdk_mode_when_create_network_attachment_definitions_then_core_nad_has_valid_dpdk_core_resource_specified_in_annotations(  # noqa: E501
-        self, patched_list, patch_get_service, kubernetes_create_object
+        self, set_can_connect_containers, enable_huge_pages_multus_and_dpdk
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patched_list.side_effect = [
+        self.mock_running_service()
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1309,37 +1158,23 @@ class TestCharm(unittest.TestCase):
                 None,
             )
 
-        create_nad_calls = kubernetes_create_object.mock_calls
+        create_nad_calls = self.mock_client_create.mock_calls
         create_core_nad_calls = [
             _get_create_core_nad_call(create_nad_call)
             for create_nad_call in create_nad_calls
             if _get_create_core_nad_call(create_nad_call)
         ]
-        self.assertEqual(len(create_core_nad_calls), 1)
+        assert len(create_core_nad_calls) == 1
         nad_annotations = create_core_nad_calls[0].get("obj").metadata.annotations
-        self.assertTrue(
-            DPDK_CORE_INTERFACE_RESOURCE_NAME in nad_annotations["k8s.v1.cni.cncf.io/resourceName"]
-        )
+        assert DPDK_CORE_INTERFACE_RESOURCE_NAME in nad_annotations["k8s.v1.cni.cncf.io/resourceName"]  # noqa: E501
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_patch_statefulset_then_2_network_annotations_are_created(  # noqa: E501
-        self, patch_get_service, kubernetes_statefulset_patch
+        self, set_can_connect_containers, enable_huge_pages_multus_and_dpdk
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
+        self.mock_running_service()
         self.harness.update_config()
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1355,27 +1190,15 @@ class TestCharm(unittest.TestCase):
                 NetworkAnnotation.NETWORK_ANNOTATION_RESOURCE_KEY
             )
         )
-        self.assertEqual(len(network_annotations), 2)
+        assert len(network_annotations) == 2
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_generate_network_annotations_is_called_then_access_network_annotation_created(  # noqa: E501
-        self, patch_get_service, kubernetes_statefulset_patch
+        self, set_can_connect_containers, enable_huge_pages_multus_and_dpdk
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
+        self.mock_running_service()
         self.harness.update_config()
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1400,28 +1223,16 @@ class TestCharm(unittest.TestCase):
                 )
             )
         )
-        self.assertTrue(access_network_annotation)
-        self.assertEqual(access_network_annotation.get("interface"), ACCESS_INTERFACE_NAME)
+        assert access_network_annotation
+        assert access_network_annotation.get("interface") == ACCESS_INTERFACE_NAME
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_generate_network_annotations_is_called_then_access_network_annotation_created_without_dpdk_specific_data(  # noqa: E501
-        self, patch_get_service, kubernetes_statefulset_patch
+        self, set_can_connect_containers, enable_huge_pages_multus_and_dpdk
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
+        self.mock_running_service()
         self.harness.update_config()
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1446,28 +1257,16 @@ class TestCharm(unittest.TestCase):
                 )
             )
         )
-        self.assertFalse(access_network_annotation.get("mac"))
-        self.assertFalse(access_network_annotation.get("ips"))
+        assert not access_network_annotation.get("mac")
+        assert not access_network_annotation.get("ips")
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_generate_network_annotations_is_called_then_core_network_annotation_created(  # noqa: E501
-        self, patch_get_service, kubernetes_statefulset_patch
+        self, set_can_connect_containers, enable_huge_pages_multus_and_dpdk
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
+        self.mock_running_service()
         self.harness.update_config()
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1492,28 +1291,16 @@ class TestCharm(unittest.TestCase):
                 )
             )
         )
-        self.assertTrue(access_network_annotation)
-        self.assertEqual(access_network_annotation.get("interface"), CORE_INTERFACE_NAME)
+        assert access_network_annotation
+        assert access_network_annotation.get("interface") == CORE_INTERFACE_NAME
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_default_mode_when_generate_network_annotations_is_called_then_core_network_annotation_created_without_dpdk_specific_data(  # noqa: E501
-        self, patch_get_service, kubernetes_statefulset_patch
+        self, set_can_connect_containers, enable_huge_pages_multus_and_dpdk
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
+        self.mock_running_service()
         self.harness.update_config()
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1538,28 +1325,15 @@ class TestCharm(unittest.TestCase):
                 )
             )
         )
-        self.assertFalse(access_network_annotation.get("mac"))
-        self.assertFalse(access_network_annotation.get("ips"))
+        assert not access_network_annotation.get("mac")
+        assert not access_network_annotation.get("ips")
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.Client.list")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_dpdk_mode_when_patch_statefulset_then_2_network_annotations_are_created(  # noqa: E501
-        self, patched_list, patch_get_service, kubernetes_statefulset_patch
+        self, set_can_connect_containers, enable_huge_pages_multus_and_dpdk
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patched_list.side_effect = [
+        self.mock_running_service()
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1574,7 +1348,7 @@ class TestCharm(unittest.TestCase):
                 "core-interface-mac-address": VALID_CORE_MAC,
             }
         )
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1590,27 +1364,14 @@ class TestCharm(unittest.TestCase):
                 NetworkAnnotation.NETWORK_ANNOTATION_RESOURCE_KEY
             )
         )
-        self.assertEqual(len(network_annotations), 2)
+        assert len(network_annotations) == 2
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.Client.list")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_upf_charm_configured_to_run_in_dpdk_mode_when_generate_network_annotations_is_called_then_access_network_annotation_created(  # noqa: E501
-        self, patched_list, patch_get_service, kubernetes_statefulset_patch
+        self, set_can_connect_containers, enable_huge_pages_multus_and_dpdk
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patched_list.side_effect = [
+        self.mock_running_service()
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1626,7 +1387,7 @@ class TestCharm(unittest.TestCase):
                 "core-interface-mac-address": VALID_CORE_MAC,
             }
         )
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1651,30 +1412,18 @@ class TestCharm(unittest.TestCase):
                 )
             )
         )
-        self.assertTrue(access_network_annotation)
-        self.assertEqual(access_network_annotation.get("interface"), ACCESS_INTERFACE_NAME)
-        self.assertEqual(access_network_annotation.get("mac"), VALID_ACCESS_MAC)
-        self.assertEqual(access_network_annotation.get("ips"), [VALID_ACCESS_IP])
+        assert access_network_annotation
+        assert access_network_annotation.get("interface") == ACCESS_INTERFACE_NAME
+        assert access_network_annotation.get("mac") == VALID_ACCESS_MAC
+        assert access_network_annotation.get("ips") == [VALID_ACCESS_IP]
 
-    @patch("lightkube.core.client.Client.patch")
-    @patch("ops.model.Container.get_service")
-    @patch("lightkube.core.client.Client.list")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
+
     def test_given_upf_charm_configured_to_run_in_dpdk_mode_when_generate_network_annotations_is_called_then_core_network_annotation_created(  # noqa: E501
-        self, patched_list, patch_get_service, kubernetes_statefulset_patch
+        self, set_can_connect_containers, enable_huge_pages_multus_and_dpdk
     ):
-        self.harness.set_can_connect("bessd", True)
-        self.harness.set_can_connect("pfcp-agent", True)
         self.harness.handle_exec("bessd", [], result=0)
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
-        patched_list.side_effect = [
+        self.mock_running_service()
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1690,7 +1439,7 @@ class TestCharm(unittest.TestCase):
                 "core-interface-mac-address": VALID_CORE_MAC,
             }
         )
-        patch_statefulset = kubernetes_statefulset_patch.call_args_list[0]
+        patch_statefulset = self.mock_k8s_statefulset_patch.call_args_list[0]
         patch_statefulset_call_args = next(
             iter(
                 filter(
@@ -1715,45 +1464,41 @@ class TestCharm(unittest.TestCase):
                 )
             )
         )
-        self.assertTrue(access_network_annotation)
-        self.assertEqual(access_network_annotation.get("interface"), CORE_INTERFACE_NAME)
-        self.assertEqual(access_network_annotation.get("mac"), VALID_CORE_MAC)
-        self.assertEqual(access_network_annotation.get("ips"), [VALID_CORE_IP])
+        assert access_network_annotation
+        assert access_network_annotation.get("interface") == CORE_INTERFACE_NAME
+        assert access_network_annotation.get("mac") == VALID_CORE_MAC
+        assert access_network_annotation.get("ips") == [VALID_CORE_IP]
 
-    @patch("charm.check_output")
-    @patch("charm.Client", new=Mock)
-    def test_given_cpu_not_supporting_required_instructions_when_install_then_charm_goes_to_blocked_status(  # noqa: E501
-        self, patched_check_output
+    def test_given_cpu_not_supporting_required_instructions_on_collect_status_then_goes_to_blocked_status(  # noqa: E501
+        self,
     ):
-        patched_check_output.return_value = b"Flags: ssse3 fma cx16 rdrand"
-        self.harness.charm.on.install.emit()
+        mock_cpu_info = TestCharm.patcher_check_output.start()
+        mock_cpu_info.return_value = b"Flags: ssse3 fma cx16 rdrand"
+
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("CPU is not compatible, see logs for more details"),
+        assert self.harness.model.unit.status == BlockedStatus(
+            "CPU is not compatible, see logs for more details"
         )
 
-    @patch("charm.check_output")
-    @patch("charm.Client", new=Mock)
     def test_given_cpu_supporting_required_instructions_when_install_then_charm_goes_to_maintenance_status(  # noqa: E501
-        self, patched_check_output
+        self,
     ):
-        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand"
+        mock_cpu_info = TestCharm.patcher_check_output.start()
+        mock_cpu_info.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand"
 
         self.harness.charm.on.install.emit()
 
-        self.assertEqual(self.harness.model.unit.status, MaintenanceStatus())
+        assert self.harness.model.unit.status == MaintenanceStatus()
 
-    @patch("charm.Client")
-    def test_when_install_then_external_service_is_created(self, patch_client):
+    def test_when_install_then_external_service_is_created(self):
         self.harness.charm.on.install.emit()
 
         expected_service = Service(
             apiVersion="v1",
             kind="Service",
             metadata=ObjectMeta(
-                namespace=self.namespace,
+                namespace=NAMESPACE,
                 name=f"{self.harness.charm.app.name}-external",
                 labels={
                     "app.kubernetes.io/name": self.harness.charm.app.name,
@@ -1764,60 +1509,46 @@ class TestCharm(unittest.TestCase):
                     "app.kubernetes.io/name": self.harness.charm.app.name,
                 },
                 ports=[
-                    ServicePort(name="pfcp", port=8805, protocol="UDP"),
+                    ServicePort(name="pfcp", port=TEST_PFCP_PORT, protocol="UDP"),
                 ],
                 type="LoadBalancer",
             ),
         )
 
-        patch_client.return_value.apply.assert_called_once_with(
+        self.mock_client_apply.assert_called_once_with(
             expected_service, field_manager="sdcore-upf-k8s"
         )
 
-    @patch("charm.Client")
-    def test_given_service_exists_on_remove_then_external_service_is_deleted(self, patch_client):
+    def test_given_service_exists_on_remove_then_external_service_is_deleted(self):
         self.harness.charm.on.remove.emit()
 
-        patch_client.return_value.delete.assert_called_once_with(
+        self.mock_client_delete.assert_called_once_with(
             Service,
             name=f"{self.harness.charm.app.name}-external",
-            namespace=self.namespace,
+            namespace=NAMESPACE,
         )
 
-    @patch("charm.Client")
-    def test_given_service_does_not_exist_on_remove_then_no_exception_is_thrown(
-        self, patch_client
-    ):
-        patch_client.return_value.delete.side_effect = HTTPStatusError(
+    def test_given_service_does_not_exist_on_remove_then_no_exception_is_thrown(self):
+        self.mock_client_delete.side_effect = HTTPStatusError(
             message='services "upf-external" not found',
             request=None,
             response=None,
         )
         self.harness.charm.on.remove.emit()
 
-        patch_client.return_value.delete.assert_called_once_with(
+        self.mock_client_delete.assert_called_once_with(
             Service,
             name=f"{self.harness.charm.app.name}-external",
-            namespace=self.namespace,
+            namespace=NAMESPACE,
         )
 
-    @patch("lightkube.core.client.Client.create")
-    @patch("ops.model.Container.get_service")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_default_config_when_create_network_attachment_definitions_then_interface_mtu_not_set_in_the_network_attachment_definitions(  # noqa: E501
-        self, patch_get_service, kubernetes_create_object
+        self, enable_huge_pages_multus_and_dpdk
     ):
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
+        self.mock_running_service()
         self.harness.update_config(
             key_values={
-                "access-ip": "192.168.252.3/24",
+                "access-ip": DEFAULT_ACCESS_IP,
                 "access-gateway-ip": ACCESS_GW_IP,
                 "gnb-subnet": GNB_SUBNET,
                 "core-ip": VALID_CORE_IP,
@@ -1825,29 +1556,22 @@ class TestCharm(unittest.TestCase):
             }
         )
 
-        create_nad_calls = kubernetes_create_object.call_args_list
+        create_nad_calls = self.mock_client_create.call_args_list
         for create_nad_call in create_nad_calls:
             create_nad_call_args = next(
                 iter(filter(lambda call_item: isinstance(call_item, dict), create_nad_call))
             )
             nad_config = json.loads(create_nad_call_args.get("obj").spec.get("config"))
-            self.assertNotIn("mtu", nad_config)
+            assert "mtu" not in nad_config
 
-    @patch("charm.check_output")
-    @patch("lightkube.core.client.Client.list")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    @patch("dpdk.DPDK.is_configured")
     def test_given_cpu_supporting_required_hugepages_instructions_when_hugepages_enabled_then_charm_goes_to_waiting_status(  # noqa: E501
-        self,
-        patch_dpdk_is_configured,
-        patch_hugepages_is_patched,
-        patch_list,
-        patched_check_output,
+        self
     ):
-        patch_dpdk_is_configured.return_value = True
-        patch_hugepages_is_patched.return_value = True
-        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        patch_list.side_effect = [
+        self.mock_dpdk_is_configured.return_value = True
+        self.mock_huge_pages_is_enabled.return_value = True
+        self.mock_cpu_info = TestCharm.patcher_check_output.start()
+        self.mock_cpu_info.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "3Gi"}))],
             [],
@@ -1865,20 +1589,19 @@ class TestCharm(unittest.TestCase):
         )
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for bessd container to be ready"),
+        assert self.harness.model.unit.status == WaitingStatus(
+            "Waiting for bessd container to be ready"
         )
 
-    @patch("charm.check_output")
-    @patch("lightkube.core.client.Client.list")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_cpu_supporting_required_hugepages_instructions_and_not_available_hugepages_when_hugepages_enabled_then_charm_goes_to_blocked_status(  # noqa: E501
-        self, patch_hugepages_is_patched, patch_list, patched_check_output
+        self
     ):
-        patch_hugepages_is_patched.return_value = False
-        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        patch_list.return_value = [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "1Gi"}))]
+        self.mock_huge_pages_is_enabled.return_value = False
+        self.mock_cpu_info = TestCharm.patcher_check_output.start()
+        self.mock_cpu_info.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        self.mock_client_list.return_value = [
+            Node(status=NodeStatus(allocatable={"hugepages-1Gi": "1Gi"}))
+        ]
 
         self.harness.update_config(
             key_values={
@@ -1890,26 +1613,16 @@ class TestCharm(unittest.TestCase):
         )
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Not enough HugePages available"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Not enough HugePages available")
 
-    @patch("charm.check_output")
-    @patch("lightkube.core.client.Client.list")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    @patch("dpdk.DPDK.is_configured")
     def test_given_hugepages_not_available_then_hugepages_available_when_update_status_then_charm_goes_to_waiting_status(  # noqa: E501
-        self,
-        patch_dpdk_is_configured,
-        patch_hugepages_is_patched,
-        patch_list,
-        patched_check_output,
+        self
     ):
-        patch_dpdk_is_configured.return_value = True
-        patch_hugepages_is_patched.return_value = True
-        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        patch_list.side_effect = [
+        self.mock_dpdk_is_configured.return_value = True
+        self.mock_huge_pages_is_enabled.return_value = True
+        self.mock_cpu_info = TestCharm.patcher_check_output.start()
+        self.mock_cpu_info.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+        self.mock_client_list.side_effect = [
             [Node(status=NodeStatus(allocatable={"hugepages-1Gi": "1Gi"}))],
             [],
             [],
@@ -1928,50 +1641,35 @@ class TestCharm(unittest.TestCase):
         )
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus("Not enough HugePages available"),
-        )
+        assert self.harness.model.unit.status == BlockedStatus("Not enough HugePages available")
 
         self.harness.charm.on.update_status.emit()
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for bessd container to be ready"),
+        assert self.harness.model.unit.status == WaitingStatus(
+            "Waiting for bessd container to be ready"
         )
 
-    @patch("charm.check_output")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.multus_is_available")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    def test_given_multus_disabled_then_enabled_when_update_status_then_status_is_active(
-        self, patch_hugepages_is_patched, patch_multus_available, patched_check_output
-    ):
-        patch_hugepages_is_patched.return_value = True
-        patch_multus_available.side_effect = [False, False, False, True]
-        patched_check_output.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
-        self.harness.charm.on.update_status.emit()
-        self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status, BlockedStatus("Multus is not installed or enabled")
-        )
-        self.harness.charm.on.update_status.emit()
+    def test_given_multus_disabled_when_collect_status_then_status_is_blocked(self):
+        mock_multus = patch(f"{MULTUS_LIBRARY}.multus_is_available").start()
+        mock_multus.return_value = False
+        self.mock_cpu_info = TestCharm.patcher_check_output.start()
+        self.mock_huge_pages_is_enabled.return_value = True
+        self.mock_cpu_info.return_value = b"Flags: avx2 ssse3 fma cx16 rdrand pdpe1gb"
+
         self.harness.evaluate_status()
 
-        self.assertEqual(
-            self.harness.model.unit.status,
-            WaitingStatus("Waiting for bessd container to be ready"),
+        assert self.harness.model.unit.status == BlockedStatus(
+            "Multus is not installed or enabled"
         )
 
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_default_config_when_network_attachment_definitions_from_config_is_called_then_no_interface_mtu_specified_in_nad(  # noqa: E501
-        self,
-        patch_hugepages_is_patched,
+        self
     ):
-        patch_hugepages_is_patched.return_value = True
+        self.mock_huge_pages_is_enabled.return_value = True
         self.harness.update_config(
             key_values={
-                "access-ip": "192.168.252.3/24",
+                "access-ip": DEFAULT_ACCESS_IP,
                 "access-gateway-ip": ACCESS_GW_IP,
                 "gnb-subnet": GNB_SUBNET,
                 "core-ip": VALID_CORE_IP,
@@ -1981,25 +1679,15 @@ class TestCharm(unittest.TestCase):
         nads = self.harness.charm._network_attachment_definitions_from_config()
         for nad in nads:
             config = json.loads(nad.spec["config"])
-            self.assertNotIn("mtu", config)
+            assert "mtu" not in config
 
-    @patch("lightkube.core.client.Client.create")
-    @patch("ops.model.Container.get_service")
-    @patch(
-        f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched",
-        Mock(return_value=True),
-    )
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready", Mock(return_value=True))
-    @patch("charm.DPDK.is_configured", Mock(return_value=True))
     def test_given_default_config_with_interfaces_mtu_sizes_when_create_network_attachment_definitions_then_interface_mtu_set_in_the_network_attachment_definitions(  # noqa: E501
-        self, patch_get_service, kubernetes_create_object
+        self, enable_huge_pages_multus_and_dpdk
     ):
-        service_info_mock = Mock()
-        service_info_mock.is_running.return_value = True
-        patch_get_service.return_value = service_info_mock
+        self.mock_running_service()
         self.harness.update_config(
             key_values={
-                "access-ip": "192.168.252.3/24",
+                "access-ip": DEFAULT_ACCESS_IP,
                 "access-gateway-ip": ACCESS_GW_IP,
                 "access-interface-mtu-size": VALID_MTU_SIZE_1,
                 "gnb-subnet": GNB_SUBNET,
@@ -2009,142 +1697,84 @@ class TestCharm(unittest.TestCase):
             }
         )
 
-        create_nad_calls = kubernetes_create_object.call_args_list
+        create_nad_calls = self.mock_client_create.call_args_list
         for create_nad_call in create_nad_calls:
             create_nad_call_args = next(
                 iter(filter(lambda call_item: isinstance(call_item, dict), create_nad_call))
             )
             nad_config = json.loads(create_nad_call_args.get("obj").spec.get("config"))
-            self.assertEqual(nad_config["mtu"], VALID_MTU_SIZE_1)
+            assert nad_config["mtu"] == VALID_MTU_SIZE_1
 
-    def test_given_default_config_with_interfaces_too_small_and_too_big_mtu_sizes_when_network_attachment_definitions_from_config_is_called_then_status_is_blocked(  # noqa: E501
-        self,
-    ):
-        self.harness.update_config(
-            key_values={
-                "access-interface-mtu-size": TOO_SMALL_MTU_SIZE,
-                "core-interface-mtu-size": TOO_BIG_MTU_SIZE,
-            }
-        )
-        self.harness.evaluate_status()
-        self.assertEqual(
-            self.harness.model.unit.status,
-            BlockedStatus(
-                "The following configurations are not valid: ['access-interface-mtu-size', 'core-interface-mtu-size']"  # noqa: E501, W505
-            ),
-        )
-
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.delete_pod")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_container_can_connect_bessd_pebble_ready_when_core_net_mtu_config_changed_to_a_different_valid_value_then_delete_pod_is_called(  # noqa: E501
-        self,
-        patch_hugepages_is_patched,
-        patch_delete_pod,
-        patch_multus_is_ready,
-        patch_list_na_definitions,
-        _,
+        self, set_can_connect_containers
     ):
+        mock_list_na_definitions = TestCharm.patcher_list_na_definitions.start()
+        mock_delete_pod = TestCharm.patcher_delete_pod.start()
         self.harness.handle_exec("bessd", [], result=0)
-        patch_hugepages_is_patched.return_value = True
-        patch_multus_is_ready.return_value = True
-        self.harness.set_can_connect(container="bessd", val=True)
-        self.harness.set_can_connect(container="pfcp-agent", val=True)
+        self.mock_huge_pages_is_enabled.return_value = True
+        self.mock_multus_is_ready.return_value = True
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
-        update_nad_labels(original_nads, self.harness.charm.app.name)
-        patch_list_na_definitions.return_value = original_nads
-        self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_1})
-        patch_delete_pod.assert_called_once()
+        set_nad_metadata_labels(original_nads, self.harness.charm.app.name)
+        mock_list_na_definitions.return_value = original_nads
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.delete_pod")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
+        self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_1})
+
+        mock_delete_pod.assert_called_once()
+
     def test_given_container_can_connect_bessd_pebble_ready_when_core_net_mtu_config_changed_to_different_valid_values_then_delete_pod_called_twice(  # noqa: E501
-        self,
-        patch_hugepages_is_patched,
-        patch_delete_pod,
-        patch_multus_is_ready,
-        patch_list_na_definitions,
-        _,
+        self, set_can_connect_containers
     ):
+        mock_list_na_definitions = TestCharm.patcher_list_na_definitions.start()
+        mock_delete_pod = TestCharm.patcher_delete_pod.start()
         self.harness.handle_exec("bessd", [], result=0)
-        patch_hugepages_is_patched.return_value = True
-        patch_multus_is_ready.return_value = True
-        self.harness.set_can_connect(container="bessd", val=True)
-        self.harness.set_can_connect(container="pfcp-agent", val=True)
+        self.mock_huge_pages_is_enabled.return_value = True
+        self.mock_multus_is_ready.return_value = True
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
-        update_nad_labels(original_nads, self.harness.charm.app.name)
-        patch_list_na_definitions.return_value = original_nads
+        set_nad_metadata_labels(original_nads, self.harness.charm.app.name)
+        mock_list_na_definitions.return_value = original_nads
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_1})
         modified_nads = self.harness.charm._network_attachment_definitions_from_config()
-        update_nad_labels(modified_nads, self.harness.charm.app.name)
-        patch_list_na_definitions.return_value = modified_nads
+        set_nad_metadata_labels(modified_nads, self.harness.charm.app.name)
+        mock_list_na_definitions.return_value = modified_nads
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})
-        self.assertEqual(patch_delete_pod.call_count, 2)
+        assert mock_delete_pod.call_count == 2
 
-    @patch("ops.model.Container.get_service")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient", new=Mock)
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.list_network_attachment_definitions")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesClient.delete_pod")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
     def test_given_container_can_connect_bessd_pebble_ready_when_core_net_mtu_config_changed_to_same_valid_value_multiple_times_then_delete_pod_called_once(  # noqa: E501
-        self,
-        patch_hugepages_is_patched,
-        patch_delete_pod,
-        patch_multus_is_ready,
-        patch_list_na_definitions,
-        _,
+        self, set_can_connect_containers
     ):
+        mock_list_na_definitions = TestCharm.patcher_list_na_definitions.start()
+        mock_delete_pod = TestCharm.patcher_delete_pod.start()
         self.harness.handle_exec("bessd", [], result=0)
         """Delete pod is called for the first config change, setting the same config value does not trigger pod restarts."""  # noqa: E501, W505
-        patch_hugepages_is_patched.return_value = True
-        patch_multus_is_ready.return_value = True
-        self.harness.set_can_connect(container="bessd", val=True)
-        self.harness.set_can_connect(container="pfcp-agent", val=True)
+        self.mock_huge_pages_is_enabled.return_value = True
+        self.mock_multus_is_ready.return_value = True
         original_nads = self.harness.charm._network_attachment_definitions_from_config()
-        update_nad_labels(original_nads, self.harness.charm.app.name)
-        patch_list_na_definitions.return_value = original_nads
+        set_nad_metadata_labels(original_nads, self.harness.charm.app.name)
+        mock_list_na_definitions.return_value = original_nads
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})
-        patch_delete_pod.assert_called_once()
+        mock_delete_pod.assert_called_once()
         nads_after_first_config_change = (
             self.harness.charm._network_attachment_definitions_from_config()
         )
-        update_nad_labels(nads_after_first_config_change, self.harness.charm.app.name)
-        patch_list_na_definitions.return_value = nads_after_first_config_change
+        set_nad_metadata_labels(nads_after_first_config_change, self.harness.charm.app.name)
+        mock_list_na_definitions.return_value = nads_after_first_config_change
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})
-        patch_delete_pod.assert_called_once()
+        mock_delete_pod.assert_called_once()
         nads_after_second_config_change = (
             self.harness.charm._network_attachment_definitions_from_config()
         )
-        update_nad_labels(nads_after_second_config_change, self.harness.charm.app.name)
+        set_nad_metadata_labels(nads_after_second_config_change, self.harness.charm.app.name)
         for nad in nads_after_second_config_change:
             nad.metadata.labels = {"app.juju.is/created-by": self.harness.charm.app.name}
-        patch_list_na_definitions.return_value = nads_after_second_config_change
+        mock_list_na_definitions.return_value = nads_after_second_config_change
         self.harness.update_config(key_values={"core-interface-mtu-size": VALID_MTU_SIZE_2})
-        patch_delete_pod.assert_called_once()
+        mock_delete_pod.assert_called_once()
 
-    @patch("ops.model.Container.get_service")
-    @patch("charm.UPFOperatorCharm.delete_pod")
-    @patch(f"{MULTUS_LIBRARY_PATH}.KubernetesMultusCharmLib.is_ready")
-    @patch(f"{HUGEPAGES_LIBRARY_PATH}.KubernetesHugePagesPatchCharmLib.is_patched")
-    def test_given_hardware_checksum_is_enabled_when_value_changes_then_delete_pod_is_called_once(  # noqa: E501
-        self,
-        patch_hugepages_is_patched,
-        patch_multus_is_ready,
-        patch_delete_pod,
-        _,
+    def test_given_hardware_checksum_is_disabled_when_value_changes_then_delete_pod_is_called_once(  # noqa: E501
+        self, set_can_connect_containers
     ):
         self.harness.handle_exec("bessd", [], result=0)
-        patch_hugepages_is_patched.return_value = True
-        patch_multus_is_ready.return_value = True
-        self.harness.set_can_connect(container="bessd", val=True)
-        self.harness.set_can_connect(container="pfcp-agent", val=True)
+        self.mock_huge_pages_is_enabled.return_value = True
+        self.mock_multus_is_ready.return_value = True
         self.harness.update_config(key_values={"enable-hw-checksum": False})
-        patch_delete_pod.assert_called_once()
+        self.mock_client_delete.assert_called_once()


### PR DESCRIPTION
# Description

FINAL PART: `TestCharm` class in `tests/unit/test_charm.py`

Remove `unittest` and use `pytest` framework to run the unit tests.
Now we have 460 lines less on this file

Actions on this PR:

- Add a `@pytest.fixture` for harness
- Add a `@pytest.fixture` to setup patches and mocks
- Continue using `Mock`, `call` and `patch` from the `unittest.Mock` library
- Use `assert` instead of `self.assert...` methods
- Parameterized test using `@pytest.mark.parametrize`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
