### PR TITLE
chore: combine dependabot updates in weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -3,23 +3,35 @@ updates:
   - package-ecosystem: "github-actions"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore: "
+    groups:
+      github_actions:
+        patterns:
+          - "*"
 
   - package-ecosystem: "pip"
     directory: "/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore: "
+    groups:
+      pip_dependencies:
+        patterns:
+          - "*"
 
   - package-ecosystem: "terraform"
     directory: "/terraform/"
     schedule:
-      interval: "daily"
+      interval: "weekly"
     commit-message:
       prefix: "chore: "
+    groups:
+      terraform_modules:
+        patterns:
+          - "*"
 
   - package-ecosystem: "github-actions"
     target-branch: v1.4


### PR DESCRIPTION
# Description

This PR aims to combine dependabot pull requests into weekly updates.
Main changes:
* update switch from `daily` to `weekly`
* create group for `github-actions`, `pip` and `terraform`

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library