### PR TITLE
fix: Uses Juju Terraform provider >= 0.11.0

### DIFF
--- a/terraform/terraform.tf
+++ b/terraform/terraform.tf
@@ -5,7 +5,7 @@ terraform {
   required_providers {
     juju = {
       source  = "juju/juju"
-      version = "~> 0.12.0"
+      version = ">= 0.11.0"
     }
   }
 }


### PR DESCRIPTION
# Description

Setting Terraform provider to a fixed version creates compability issues during the SD-Core deployment. Hence, it will be set to >= 0.11.0.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
