### PR TITLE
fix: Charm doesn't handle missing Multus correctly

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ sudo microk8s enable multus
 
 Install Juju and bootstrap a controller on the MicroK8S instance:
 ```shell
-sudo snap install juju --channel=3.1/stable
+sudo snap install juju --channel=3.4/stable
 juju bootstrap microk8s
 ```
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -570,6 +570,8 @@ class UPFOperatorCharm(CharmBase):
             return
         if not self._hugepages_are_available():
             return
+        if not self._kubernetes_multus.multus_is_available():
+            return
         if not self._kubernetes_multus.is_ready():
             return
         if not path_exists(container=self._bessd_container, path=BESSD_CONTAINER_CONFIG_PATH):


### PR DESCRIPTION
# Description

We get an `hook failed: "storage-attached"` failure on UPF k8s charm when multus is not enabled.

This PR fixes it. Now, when Multus is not available in the K8s cluster, the UPF charm remains in `BlockedStatus` with a proper error message. 

![image](https://github.com/user-attachments/assets/64a581e0-b87a-4433-b5d1-9ac4b06c2929)


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
