### PR TITLE
chore: replace ops.main.main() with ops.main

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -30,10 +30,17 @@ from jinja2 import Environment, FileSystemLoader
 from lightkube.core.client import Client
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Node, Pod
-from ops import ActiveStatus, BlockedStatus, Container, ModelError, RemoveEvent, WaitingStatus
+from ops import (
+    ActiveStatus,
+    BlockedStatus,
+    Container,
+    ModelError,
+    RemoveEvent,
+    WaitingStatus,
+    main,
+)
 from ops.charm import CharmBase, CollectStatusEvent
 from ops.framework import EventBase
-from ops.main import main
 from ops.pebble import ChangeError, ConnectionError, ExecError, Layer, PathError
 
 from charm_config import CharmConfig, CharmConfigInvalidError, CNIType, UpfMode
@@ -497,7 +504,7 @@ class UPFOperatorCharm(CharmBase):
         if not path_exists(
             container=self._pfcp_agent_container,
             path=PFCP_AGENT_CONTAINER_CONFIG_PATH,
-            ):
+        ):
             event.add_status(
                 WaitingStatus("Waiting for storage to be attached for pfcp-agent container")
             )


### PR DESCRIPTION
# Description

`ops.main.main()` is deprecated. Here, we replace it with `ops.main()`.

## Logs

```
/var/lib/juju/agents/unit-gnbsim-0/charm/./src/charm.py:510: DeprecationWarning: Calling ops.main.main() is deprecated, call ops.main() instead
  main(GNBSIMOperatorCharm)
```

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
