### PR TITLE
fix: Use 1.5.0 version of rocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ service port with the load balancer upon install of the charm.
 
 ## Image
 
-- **bessd**: ghcr.io/canonical/sdcore-upf-bess:1.4.0
-- **routectl**: ghcr.io/canonical/sdcore-upf-bess:1.4.0
-- **pfcp-agent**: ghcr.io/canonical/sdcore-upf-pfcpiface:1.4.0
+- **bessd**: ghcr.io/canonical/sdcore-upf-bess:1.5.0
+- **routectl**: ghcr.io/canonical/sdcore-upf-bess:1.5.0
+- **pfcp-agent**: ghcr.io/canonical/sdcore-upf-pfcpiface:1.5.0
 

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -30,12 +30,12 @@ resources:
   bessd-image:
     type: oci-image
     description: OCI image for 5G upf bessd
-    upstream-source: ghcr.io/canonical/sdcore-upf-bess:1.4.0
+    upstream-source: ghcr.io/canonical/sdcore-upf-bess:1.5.0
 
   pfcp-agent-image:
     type: oci-image
     description: OCI image for 5G upf pfcp-agent
-    upstream-source: ghcr.io/canonical/sdcore-upf-pfcpiface:1.4.0
+    upstream-source: ghcr.io/canonical/sdcore-upf-pfcpiface:1.5.0
 
 storage:
   config:

--- a/src/templates/upf.json.j2
+++ b/src/templates/upf.json.j2
@@ -15,7 +15,7 @@
   "enable_notify_bess": true,
   "gtppsc": true,
   "hwcksum": {{ hwcksum }},
-  "log_level": "trace",
+  "log_level": "info",
   "max_sessions": 50000,
   "measure_flow": false,
   "measure_upf": true,

--- a/tests/unit/expected_upf.json
+++ b/tests/unit/expected_upf.json
@@ -15,7 +15,7 @@
   "enable_notify_bess": true,
   "gtppsc": true,
   "hwcksum": true,
-  "log_level": "trace",
+  "log_level": "info",
   "max_sessions": 50000,
   "measure_flow": false,
   "measure_upf": true,


### PR DESCRIPTION
# Description

Bump the version of the rocks used to 1.5.0. Depends on https://github.com/canonical/sdcore-upf-bess-rock/pull/36

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [x] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
