### PR TITLE
feat: add log-level configuration option

### DIFF
--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -161,3 +161,7 @@ config:
       default: true
       description: |
         When enabled, hardware checksum will be used on the network interfaces.
+    log-level:
+      type: string
+      default: info
+      description: Log level for the UPF. One of `debug`, `info`, `warn`, `error`, `fatal`, `panic`.

--- a/src/charm.py
+++ b/src/charm.py
@@ -672,6 +672,7 @@ class UPFOperatorCharm(CharmBase):
             dnn=self._charm_config.dnn,
             pod_share_path=POD_SHARE_PATH,
             enable_hw_checksum=self._charm_config.enable_hw_checksum,
+            log_level=self._charm_config.log_level,
         )
         if (
             not self._upf_config_file_is_written_to_bessd_container()
@@ -1164,6 +1165,7 @@ def render_bessd_config_file(
     dnn: str,
     pod_share_path: str,
     enable_hw_checksum: bool,
+    log_level: str,
 ) -> str:
     """Render the configuration file for the 5G UPF service.
 
@@ -1176,6 +1178,7 @@ def render_bessd_config_file(
         dnn: Data Network Name (DNN)
         pod_share_path: pod_share path
         enable_hw_checksum: Whether to enable hardware checksum or not
+        log_level (str): Log level for the UPF.
     """
     jinja2_environment = Environment(loader=FileSystemLoader("src/templates/"))
     template = jinja2_environment.get_template(f"{CONFIG_FILE_NAME}.j2")
@@ -1188,6 +1191,7 @@ def render_bessd_config_file(
         dnn=dnn,
         pod_share_path=pod_share_path,
         hwcksum=str(enable_hw_checksum).lower(),
+        log_level=log_level,
     )
     return content
 

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -41,6 +41,15 @@ class UpfMode(str, Enum):
     af_packet = "af_packet"
     dpdk = "dpdk"
 
+class LogLevel(str, Enum):
+    """Class to define available log levels for UPF operator."""
+
+    DEBUG = "debug"
+    INFO = "info"
+    WARN = "warn"
+    ERROR = "error"
+    FATAL = "fatal"
+    PANIC = "panic"
 
 NetworkType: TypeAlias = "str | bytes | int | tuple[str | bytes | int, str | int]"
 
@@ -85,6 +94,7 @@ class UpfConfig(BaseModel):  # pylint: disable=too-few-public-methods
     core_interface_mtu_size: Optional[int] = Field(default=None, ge=1200, le=65535)
     external_upf_hostname: Optional[StrictStr] = Field(default="")
     enable_hw_checksum: bool = True
+    log_level: LogLevel = LogLevel.INFO
 
     @model_validator(mode="after")
     def validate_upf_mode_with_mac_addresses(self):
@@ -153,6 +163,7 @@ class CharmConfig:
     core_interface_mtu_size: Optional[int]
     external_upf_hostname: Optional[StrictStr]
     enable_hw_checksum: bool
+    log_level: LogLevel
 
     def __init__(self, *, upf_config: UpfConfig):
         """Initialize a new instance of the CharmConfig class.
@@ -176,6 +187,7 @@ class CharmConfig:
         self.core_interface_mtu_size = upf_config.core_interface_mtu_size
         self.external_upf_hostname = upf_config.external_upf_hostname
         self.enable_hw_checksum = upf_config.enable_hw_checksum
+        self.log_level = upf_config.log_level
 
     @classmethod
     def from_charm(

--- a/src/templates/upf.json.j2
+++ b/src/templates/upf.json.j2
@@ -15,7 +15,7 @@
   "enable_notify_bess": true,
   "gtppsc": true,
   "hwcksum": {{ hwcksum }},
-  "log_level": "info",
+  "log_level": "{{ log_level }}",
   "max_sessions": 50000,
   "measure_flow": false,
   "measure_upf": true,


### PR DESCRIPTION
# Description

Here we add a `log-level` configuration option with a reasonable default value (`info`). The allowed options are the same as in the workload: `debug`, `info`, `warn`, `error`, `fatal`, `panic`.

## Rationale

In most deployments, the log level should be set to `info` to ensure the log quantity is reasonable. 


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
