### PR TITLE
chore: specify base as ubuntu@24.04

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -9,6 +9,7 @@ resource "juju_application" "upf" {
     name     = "sdcore-upf-k8s"
     channel  = var.channel
     revision = var.revision
+    base     = var.base
   }
 
   config      = var.config

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -13,6 +13,12 @@ variable "channel" {
   default     = "1.6/edge"
 }
 
+variable "base" {
+  description = "The base to use when deploying a charm."
+  type        = string
+  default     = "ubuntu@24.04"
+}
+
 variable "config" {
   description = "Application config. Details about available options can be found at https://charmhub.io/sdcore-upf-k8s-operator/configure."
   type        = map(string)


### PR DESCRIPTION
# Description

If cham base is not specified, the charm from 1.6/edge track is deployed with Ubuntu22.04 base in some hosts. The host OS  affects the base selection. This PR helps to always deploy the charm with base Ubuntu 24.04.


# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
