### PR TITLE
fix: Fixes Unauthorized error when listing K8s nodes

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -28,6 +28,7 @@ from charms.sdcore_upf_k8s.v0.fiveg_n3 import N3Provides
 from charms.sdcore_upf_k8s.v0.fiveg_n4 import N4Provides
 from jinja2 import Environment, FileSystemLoader
 from lightkube.core.client import Client
+from lightkube.core.exceptions import ApiError
 from lightkube.models.meta_v1 import ObjectMeta
 from lightkube.resources.core_v1 import Node, Pod
 from ops import (
@@ -1112,10 +1113,17 @@ class UPFOperatorCharm(CharmBase):
         Returns:
             bool: Whether HugePages are available in the K8S nodes
         """
-        client = Client()
-        nodes = client.list(Node)
         if not self._hugepages_is_enabled():
             return True
+        client = Client()
+        try:
+            nodes = client.list(Node)
+        except ApiError as e:
+            if e.status.reason == "Unauthorized":
+                logger.debug("kube-apiserver not ready yet")
+                return False
+            else:
+                raise e
         if not nodes:
             return False
         return all(node.status.allocatable.get("hugepages-1Gi", "0") >= "2Gi" for node in nodes)  # type: ignore


### PR DESCRIPTION
# Description

When `kube-apiserver` isn't ready, fetching list of K8s nodes fails with `Unauthorized` error. This fix handles such situation by catching the error and logging the relevant message rather than raising an error which puts the charm in the error state.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
