### PR TITLE
chore: bump workload to v2.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ service port with the load balancer upon install of the charm.
 
 ## Image
 
-- **bessd**: ghcr.io/canonical/sdcore-upf-bess:1.5.0
-- **routectl**: ghcr.io/canonical/sdcore-upf-bess:1.5.0
-- **pfcp-agent**: ghcr.io/canonical/sdcore-upf-pfcpiface:1.5.0
-
+- **bessd**: ghcr.io/canonical/sdcore-upf-bess:2.0.0
+- **routectl**: ghcr.io/canonical/sdcore-upf-bess:2.0.0
+- **pfcp-agent**: ghcr.io/canonical/sdcore-upf-pfcpiface:2.0.0

--- a/README.md
+++ b/README.md
@@ -37,6 +37,6 @@ service port with the load balancer upon install of the charm.
 
 ## Image
 
-- **bessd**: ghcr.io/canonical/sdcore-upf-bess:2.0.0
-- **routectl**: ghcr.io/canonical/sdcore-upf-bess:2.0.0
-- **pfcp-agent**: ghcr.io/canonical/sdcore-upf-pfcpiface:2.0.0
+- **bessd**: ghcr.io/canonical/sdcore-upf-bess:2.0.1
+- **routectl**: ghcr.io/canonical/sdcore-upf-bess:2.0.1
+- **pfcp-agent**: ghcr.io/canonical/sdcore-upf-pfcpiface:2.0.1

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -30,12 +30,12 @@ resources:
   bessd-image:
     type: oci-image
     description: OCI image for 5G upf bessd
-    upstream-source: ghcr.io/canonical/sdcore-upf-bess:1.5.0
+    upstream-source: ghcr.io/canonical/sdcore-upf-bess:2.0.0
 
   pfcp-agent-image:
     type: oci-image
     description: OCI image for 5G upf pfcp-agent
-    upstream-source: ghcr.io/canonical/sdcore-upf-pfcpiface:1.5.0
+    upstream-source: ghcr.io/canonical/sdcore-upf-pfcpiface:2.0.0
 
 storage:
   config:

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -30,12 +30,12 @@ resources:
   bessd-image:
     type: oci-image
     description: OCI image for 5G upf bessd
-    upstream-source: ghcr.io/canonical/sdcore-upf-bess:2.0.0
+    upstream-source: ghcr.io/canonical/sdcore-upf-bess:2.0.1
 
   pfcp-agent-image:
     type: oci-image
     description: OCI image for 5G upf pfcp-agent
-    upstream-source: ghcr.io/canonical/sdcore-upf-pfcpiface:2.0.0
+    upstream-source: ghcr.io/canonical/sdcore-upf-pfcpiface:2.0.1
 
 storage:
   config:


### PR DESCRIPTION
# Description

Bump the underlying upf workloads to the latest upstream release: 2.0.1.

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
