### PR TITLE
fix: Fix broken configuration when masquerade is disabled

### DIFF
--- a/src/templates/upf.json.j2
+++ b/src/templates/upf.json.j2
@@ -3,8 +3,12 @@
     "ifname": "{{ access_interface_name }}"
   },
   "core": {
+    {% if core_ip_masquerade %}
     "ifname": "{{ core_interface_name }}",
     "ip_masquerade": "{{ core_ip_address }}"
+    {% else %}
+    "ifname": "{{ core_interface_name }}"
+    {% endif %}
   },
   "cpiface": {
     "dnn": "{{ dnn }}",

--- a/tests/unit/config/expected_upf_no_masquerade.json
+++ b/tests/unit/config/expected_upf_no_masquerade.json
@@ -3,8 +3,7 @@
     "ifname": "access"
   },
   "core": {
-    "ifname": "core",
-    "ip_masquerade": ""
+    "ifname": "core"
   },
   "cpiface": {
     "dnn": "internet",


### PR DESCRIPTION
# Description

The UPF fails to run when the `ip_masquerade` field is present with an empty value. This PR fixes the issue by only adding this field when masquerade is enabled.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
