### PR TITLE
fix: Remove artificial throughput limit from configuration

### DIFF
--- a/src/templates/upf.json.j2
+++ b/src/templates/upf.json.j2
@@ -35,12 +35,6 @@
       "qci": 0
     }
   ],
-  "slice_rate_limit_config": {
-    "n3_bps": 1000000000,
-    "n3_burst_bytes": 12500000,
-    "n6_bps": 1000000000,
-    "n6_burst_bytes": 12500000
-  },
   "table_sizes": {
     "appQERLookup": 200000,
     "farLookup": 150000,

--- a/tests/unit/config/expected_upf.json
+++ b/tests/unit/config/expected_upf.json
@@ -31,12 +31,6 @@
       "qci": 0
     }
   ],
-  "slice_rate_limit_config": {
-    "n3_bps": 1000000000,
-    "n3_burst_bytes": 12500000,
-    "n6_bps": 1000000000,
-    "n6_burst_bytes": 12500000
-  },
   "table_sizes": {
     "appQERLookup": 200000,
     "farLookup": 150000,

--- a/tests/unit/config/expected_upf_no_masquerade.json
+++ b/tests/unit/config/expected_upf_no_masquerade.json
@@ -30,12 +30,6 @@
       "qci": 0
     }
   ],
-  "slice_rate_limit_config": {
-    "n3_bps": 1000000000,
-    "n3_burst_bytes": 12500000,
-    "n6_bps": 1000000000,
-    "n6_burst_bytes": 12500000
-  },
   "table_sizes": {
     "appQERLookup": 200000,
     "farLookup": 150000,


### PR DESCRIPTION
# Description

This PR removes an optional section from the configuration file that put a global throughput limit.

![image](https://github.com/user-attachments/assets/78a47716-9ce9-4cd1-9416-c71c7c64766e)

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
