### PR TITLE
feat: add configuration to start BESS HTTP server

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 .coverage
 .mypy_cache/
 .tox/
+coverage.xml
 
 # Python
 **/venv/**

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -180,3 +180,4 @@ config:
       default: false
       description: |
         When enabled, UPF will expose the BESS HTTP server on port 5000.
+        WARNING: This should be enabled only for debugging purposes and disabled afterwards.

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -175,3 +175,8 @@ config:
       type: string
       default: info
       description: Log level for the UPF. One of `debug`, `info`, `warn`, `error`, `fatal`, `panic`.
+    bess-http:
+      type: boolean
+      default: false
+      description: |
+        When enabled, UPF will expose the BESS HTTP server on port 5000

--- a/charmcraft.yaml
+++ b/charmcraft.yaml
@@ -175,8 +175,8 @@ config:
       type: string
       default: info
       description: Log level for the UPF. One of `debug`, `info`, `warn`, `error`, `fatal`, `panic`.
-    bess-http:
+    enable-bess-http:
       type: boolean
       default: false
       description: |
-        When enabled, UPF will expose the BESS HTTP server on port 5000
+        When enabled, UPF will expose the BESS HTTP server on port 5000.

--- a/src/charm.py
+++ b/src/charm.py
@@ -968,7 +968,7 @@ class UPFOperatorCharm(CharmBase):
                     },
                     self._bessctl_http_service_name: {
                         "override": "replace",
-                        "startup": "enabled" if self._charm_config.bess_http else "disabled",
+                        "startup": "enabled" if self._charm_config.enable_bess_http else "disabled",  # noqa E501
                         "command": "/opt/bess/bessctl/bessctl http 0.0.0.0",
                         "requires": [self._bessd_service_name],
                         "after": [self._bessd_service_name],

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -98,7 +98,7 @@ class UpfConfig(BaseModel):  # pylint: disable=too-few-public-methods
     external_upf_hostname: Optional[StrictStr] = Field(default="")
     enable_hw_checksum: bool = True
     log_level: LogLevel = LogLevel.INFO
-    bess_http: bool = False
+    enable_bess_http: bool = False
 
     @model_validator(mode="after")
     def validate_upf_mode_with_mac_addresses(self):
@@ -150,6 +150,7 @@ class CharmConfig:
         core_interface_mtu_size: MTU for the core interface in bytes.
         external_upf_hostname: Externally accessible FQDN for the UPF.
         enable_hw_checksum: When enabled, hardware checksum will be used on the network interfaces.
+        enable_bess_http: When enabled, UPF will expose the BESS HTTP server on port 5000.
     """
 
     cni_type: CNIType
@@ -170,7 +171,7 @@ class CharmConfig:
     external_upf_hostname: Optional[StrictStr]
     enable_hw_checksum: bool
     log_level: LogLevel
-    bess_http: bool
+    enable_bess_http: bool
 
     def __init__(self, *, upf_config: UpfConfig):
         """Initialize a new instance of the CharmConfig class.
@@ -196,7 +197,7 @@ class CharmConfig:
         self.external_upf_hostname = upf_config.external_upf_hostname
         self.enable_hw_checksum = upf_config.enable_hw_checksum
         self.log_level = upf_config.log_level
-        self.bess_http = upf_config.bess_http
+        self.enable_bess_http = upf_config.enable_bess_http
 
     @classmethod
     def from_charm(

--- a/src/charm_config.py
+++ b/src/charm_config.py
@@ -98,6 +98,7 @@ class UpfConfig(BaseModel):  # pylint: disable=too-few-public-methods
     external_upf_hostname: Optional[StrictStr] = Field(default="")
     enable_hw_checksum: bool = True
     log_level: LogLevel = LogLevel.INFO
+    bess_http: bool = False
 
     @model_validator(mode="after")
     def validate_upf_mode_with_mac_addresses(self):
@@ -169,6 +170,7 @@ class CharmConfig:
     external_upf_hostname: Optional[StrictStr]
     enable_hw_checksum: bool
     log_level: LogLevel
+    bess_http: bool
 
     def __init__(self, *, upf_config: UpfConfig):
         """Initialize a new instance of the CharmConfig class.
@@ -194,6 +196,7 @@ class CharmConfig:
         self.external_upf_hostname = upf_config.external_upf_hostname
         self.enable_hw_checksum = upf_config.enable_hw_checksum
         self.log_level = upf_config.log_level
+        self.bess_http = upf_config.bess_http
 
     @classmethod
     def from_charm(

--- a/tests/unit/test_charm_bessd_pebble_ready.py
+++ b/tests/unit/test_charm_bessd_pebble_ready.py
@@ -259,10 +259,10 @@ class TestCharmBessdPebbleReady(UPFUnitTestFixtures):
             assert os.stat(f"{temp_file}/upf.json").st_mtime == config_modification_time
 
     @pytest.mark.parametrize(
-        "bess_http", [True, False], ids=["bess_http_enabled", "bess_http_disabled"]
+        "enable_bess_http", [True, False], ids=["bess_http_enabled", "bess_http_disabled"]
     )
     def test_given_bessd_container_ready_when_bessd_pebble_ready_then_pebble_layer_is_created(
-        self, bess_http
+        self, enable_bess_http
     ):
         gnb_subnet = "2.2.2.0/24"
         core_gateway_ip = "1.2.3.4"
@@ -327,7 +327,7 @@ class TestCharmBessdPebbleReady(UPFUnitTestFixtures):
                     "core-gateway-ip": core_gateway_ip,
                     "access-gateway-ip": access_gateway_ip,
                     "gnb-subnet": gnb_subnet,
-                    "bess-http": bess_http,
+                    "enable-bess-http": enable_bess_http,
                 },
             )
 
@@ -351,7 +351,7 @@ class TestCharmBessdPebbleReady(UPFUnitTestFixtures):
                             },
                             "bessctl-http": {
                                 "override": "replace",
-                                "startup": "enabled" if bess_http else "disabled",
+                                "startup": "enabled" if enable_bess_http else "disabled",
                                 "command": "/opt/bess/bessctl/bessctl http 0.0.0.0",
                                 "requires": ["bessd"],
                                 "after": ["bessd"],

--- a/tests/unit/test_charm_bessd_pebble_ready.py
+++ b/tests/unit/test_charm_bessd_pebble_ready.py
@@ -5,6 +5,7 @@
 import os
 import tempfile
 
+import pytest
 from ops import testing
 from ops.pebble import Layer, ServiceStatus
 
@@ -257,8 +258,11 @@ class TestCharmBessdPebbleReady(UPFUnitTestFixtures):
             assert actual_upf_config.strip() == expected_upf_config.strip()
             assert os.stat(f"{temp_file}/upf.json").st_mtime == config_modification_time
 
+    @pytest.mark.parametrize(
+        "bess_http", [True, False], ids=["bess_http_enabled", "bess_http_disabled"]
+    )
     def test_given_bessd_container_ready_when_bessd_pebble_ready_then_pebble_layer_is_created(
-        self,
+        self, bess_http
     ):
         gnb_subnet = "2.2.2.0/24"
         core_gateway_ip = "1.2.3.4"
@@ -323,6 +327,7 @@ class TestCharmBessdPebbleReady(UPFUnitTestFixtures):
                     "core-gateway-ip": core_gateway_ip,
                     "access-gateway-ip": access_gateway_ip,
                     "gnb-subnet": gnb_subnet,
+                    "bess-http": bess_http,
                 },
             )
 
@@ -343,6 +348,13 @@ class TestCharmBessdPebbleReady(UPFUnitTestFixtures):
                                     "CONF_FILE": "/etc/bess/conf/upf.json",
                                     "PYTHONPATH": "/opt/bess",
                                 },
+                            },
+                            "bessctl-http": {
+                                "override": "replace",
+                                "startup": "enabled" if bess_http else "disabled",
+                                "command": "/opt/bess/bessctl/bessctl http 0.0.0.0",
+                                "requires": ["bessd"],
+                                "after": ["bessd"],
                             }
                         },
                         "checks": {


### PR DESCRIPTION
# Description

This PR adds a new configuration option, `bess-http` to the UPF charm. The option accepts boolean values.
When enabled, the UPF will start and expose the bess HTTP server on port 5000.
A new service `besstl-http` is added to the `bessd` container plan. By default, the service [startup](https://documentation.ubuntu.com/pebble/reference/layer-specification/) is `disabled`.
When the configuration option is changed, the following operations are performed:
* if the new service startup value is `enabled` and the current status is `inactive`, the service is started
* if the new service startup value is `disabled` and the current status is `active`, the service is stopped

This logic is overridden when a service restart is forced by the caller of the service configuration function (the behaviour is unchanged).

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
