### PR TITLE
fix: Prevent constantly restarting bessd service

### DIFF
--- a/src/charm.py
+++ b/src/charm.py
@@ -713,12 +713,12 @@ class UPFOperatorCharm(CharmBase):
                 )
                 restart_service = True
             if service.startup == "enabled" and (
-                    self._bessd_container.get_service(service_name).current != "active"
+                    not self._bessd_container.get_service(service_name).is_running()
                     or restart_service):
                 self._bessd_container.restart(service_name)
                 logger.info("Service `%s` restarted", service_name)
             elif (service.startup == "disabled" and
-                  self._bessd_container.get_service(service_name).current != "inactive"):
+                  self._bessd_container.get_service(service_name).is_running()):
                 self._bessd_container.stop(service_name)
                 logger.info("Service `%s` stopped", service_name)
         self._wait_for_bessd_grpc_service_to_be_ready(timeout=60)


### PR DESCRIPTION
# Description

The condition to decide if the bessd service needed to be restarted was wrong, and always true. Because of that, bessd was restarted every time update_status ran.

This PR fixes the issue and adds a test to cover that situation.

# Checklist:

- [x] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [x] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [x] I have added tests that validate the behaviour of the software
- [x] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
