### PR TITLE
fix: set grafana agent channel to 1/stable in integration tests

### DIFF
--- a/tests/integration/test_integration.py
+++ b/tests/integration/test_integration.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 METADATA = yaml.safe_load(Path("./charmcraft.yaml").read_text())
 APP_NAME = METADATA["name"]
 GRAFANA_AGENT_APP_NAME = "grafana-agent-k8s"
-GRAFANA_AGENT_APP_CHANNEL = "latest/stable"
+GRAFANA_AGENT_APP_CHANNEL = "1/stable"
 
 
 async def _deploy_grafana_agent(ops_test: OpsTest):


### PR DESCRIPTION
# Description

Grafana agent charm has been released to `1/stable`. This PR updates it in the integration tests

# Checklist:

- [ ] My code follows the [style guidelines](/CONTRIBUTING.md) of this project
- [ ] I have performed a self-review of my own code
- [ ] I have made corresponding changes to the documentation
- [ ] I have added tests that validate the behaviour of the software
- [ ] I validated that new and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have bumped the version of the library
